### PR TITLE
[Common]: Carousel - Only show dots if more than 1

### DIFF
--- a/apps/datahub-e2e/src/e2e/search.cy.ts
+++ b/apps/datahub-e2e/src/e2e/search.cy.ts
@@ -35,6 +35,8 @@ describe('search', () => {
           ' Metadata for E2E testing purpose. (this title is too long and should be cut, this title is too long and should be cut, this title is too long and should be cut, this title is too long and should be cut, this title is too long and should be cut) '
         )
 
+      cy.get('.mel-carousel-step-dot').should('exist')
+
       cy.get('mel-datahub-results-card-last-created')
         .find('h1')
         .should('be.visible')
@@ -89,6 +91,8 @@ describe('search', () => {
             'have.text',
             ' Metadata for E2E testing purpose. (this title is too long and should be cut, this title is too long and should be cut, this title is too long and should be cut, this title is too long and should be cut, this title is too long and should be cut) '
           )
+
+        cy.get('.mel-carousel-step-dot').should('not.exist')
 
         cy.get('mel-datahub-results-card-favorite')
           .find('.mel-badge-button-primary')

--- a/apps/datahub/src/app/common/custom-carousel/custom-carousel.component.html
+++ b/apps/datahub/src/app/common/custom-carousel/custom-carousel.component.html
@@ -30,6 +30,7 @@
   </button>
 </div>
 
+@if(steps.length > 1){
 <div class="flex justify-center gap-3" [ngClass]="stepsContainerClass">
   @for(step of steps; track $index){
   <button
@@ -39,3 +40,4 @@
   ></button>
   }
 </div>
+}


### PR DESCRIPTION
This PR removes the dots below the carousel when there is only a single dot. If there are more or equal than 2 it will be shown.
This will improve the UI and UX since there will be no interactions possible with only one dot.

![image](https://github.com/camptocamp/mel-dataplatform/assets/133115263/afe647c3-3f53-4f76-9883-43e1ce146892)
![image](https://github.com/camptocamp/mel-dataplatform/assets/133115263/38c2a95a-555e-40d7-b370-480682dbdc70)
