### PR TITLE
Routing: Move home to root

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset.cy.ts
@@ -235,7 +235,7 @@ describe('datasets', () => {
       })
     })
     describe('Without a query on', () => {
-      beforeEach(() => cy.visit('/home'))
+      beforeEach(() => cy.visit('/'))
       it('should return to the dataset list on the search page', () => {
         cy.get('mel-datahub-results-card-last-created').first().click()
 

--- a/apps/datahub-e2e/src/e2e/home.cy.ts
+++ b/apps/datahub-e2e/src/e2e/home.cy.ts
@@ -1,5 +1,5 @@
 describe('home', () => {
-  beforeEach(() => cy.visit('/home'))
+  beforeEach(() => cy.visit('/'))
 
   describe('home header search', () => {
     it('should display the title', () => {

--- a/apps/datahub/src/app/app.router.service.ts
+++ b/apps/datahub/src/app/app.router.service.ts
@@ -1,20 +1,22 @@
-import { Injectable } from '@angular/core';
-import { Routes } from '@angular/router';
-import { RouterService } from 'geonetwork-ui';
-import { HomePageComponent } from './home/home-page/home-page.component';
+import { Injectable } from '@angular/core'
+import { Routes } from '@angular/router'
+import { RouterService } from 'geonetwork-ui'
+import { HomePageComponent } from './home/home-page/home-page.component'
 
 @Injectable()
 export class AppRouterService extends RouterService {
   override buildRoutes(): Routes {
+    const routes = super.buildRoutes()
+    const routesWithoutRoot = routes.filter((route) => route.path !== '')
     return [
-      ...super.buildRoutes(),
+      ...routesWithoutRoot,
       {
-        path: 'home',
+        path: '',
         component: HomePageComponent,
         data: {
           shouldDetach: true,
         },
       },
-    ];
+    ]
   }
 }


### PR DESCRIPTION
The PR moves `/home` to `/` and removes the redirection from `/` to `/search`.