### PR TITLE
Update gn-ui

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@ngx-translate/core": "^15.0.0",
         "@nx/angular": "17.2.8",
         "@vendure/ngx-translate-extract": "^9.0.3",
-        "geonetwork-ui": "^2.2.0-dev.cbcafed5",
+        "geonetwork-ui": "^2.2.0-dev.95b40cd8",
         "rxjs": "~7.8.0",
         "tippy.js": "^6.3.7",
         "tslib": "^2.3.0",
@@ -7049,9 +7049,9 @@
       }
     },
     "node_modules/@petamoriken/float16": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.5.tgz",
-      "integrity": "sha512-XCO48r7/l1BMzA0DuB9/osQ6cXWk3PUl90RqFUjR2DB/LIpY98aEpzjYTkiRh2a5nTgEA8kDFDy88O0Kiib/wA=="
+      "version": "3.8.6",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.6.tgz",
+      "integrity": "sha512-GNJhABTtcmt9al/nqdJPycwFD46ww2+q2zwZzTjY0dFFwUAFRw9zszvEr9osyJRd9krRGy6hUDopWUg9fX7VVw=="
     },
     "node_modules/@phenomnomnominal/tsquery": {
       "version": "5.0.1",
@@ -14193,9 +14193,9 @@
       }
     },
     "node_modules/geonetwork-ui": {
-      "version": "2.2.0-dev.cbcafed5",
-      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.2.0-dev.cbcafed5.tgz",
-      "integrity": "sha512-Xo3TJqa/kUsl1vPsNT++WnZOipkw5Q+a8VSvvlS8lAAIfvAVzCo+wT/7mRkaRUfloAS2M8+2V8fnNmx2y3k5fg==",
+      "version": "2.2.0-dev.95b40cd8",
+      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.2.0-dev.95b40cd8.tgz",
+      "integrity": "sha512-Nf7tF1hX6xV1pWw79eUQKxltruO14EUvWV6rh4HO5COFZQxzD2VCIshXQgc9CXgDplRawp1P8qhrZHxrTCdp+Q==",
       "dependencies": {
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
         "@camptocamp/ogc-client": "^0.4.0",
@@ -16262,9 +16262,9 @@
       }
     },
     "node_modules/geonetwork-ui/node_modules/@types/node": {
-      "version": "16.18.87",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.87.tgz",
-      "integrity": "sha512-+IzfhNirR/MDbXz6Om5eHV54D9mQlEMGag6AgEzlju0xH3M8baCXYwqQ6RKgGMpn9wSTx6Ltya/0y4Z8eSfdLw==",
+      "version": "16.18.89",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.89.tgz",
+      "integrity": "sha512-QlrE8QI5z62nfnkiUZysUsAaxWaTMoGqFVcB3PvK1WxJ0c699bacErV4Fabe9Hki6ZnaHalgzihLbTl2d34XfQ==",
       "optional": true,
       "peer": true
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@ngx-translate/core": "^15.0.0",
     "@nx/angular": "17.2.8",
     "@vendure/ngx-translate-extract": "^9.0.3",
-    "geonetwork-ui": "^2.2.0-dev.cbcafed5",
+    "geonetwork-ui": "^2.2.0-dev.95b40cd8",
     "rxjs": "~7.8.0",
     "tippy.js": "^6.3.7",
     "tslib": "^2.3.0",


### PR DESCRIPTION
This update should include the improvements:
- display default baselayer on map
- recover logo from groups as a fallback