### PR TITLE
Rename plateforme to catalogue

### DIFF
--- a/apps/datahub/project.json
+++ b/apps/datahub/project.json
@@ -98,8 +98,8 @@
       "executor": "nx:run-commands",
       "options": {
         "commands": [
-          "nx build mel-datahub --base-href='/plateforme/'",
-          "docker build --build-arg APP_NAME=plateforme -f ./tools/docker/Dockerfile . -t ghcr.io/camptocamp/mel-dataplatform/datahub:latest"
+          "nx build mel-datahub --base-href='/catalogue/'",
+          "docker build --build-arg APP_NAME=catalogue -f ./tools/docker/Dockerfile . -t ghcr.io/camptocamp/mel-dataplatform/datahub:latest"
         ],
         "parallel": false
       }

--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -177,7 +177,7 @@ import { environment } from '../environments/environnment'
     { provide: GN_UI_VERSION, useValue: environment.version },
     {
       provide: WEB_COMPONENT_EMBEDDER_URL,
-      useFactory: () => '/plateforme/wc-embedder.html',
+      useFactory: () => '/catalogue/wc-embedder.html',
     },
     provideRepositoryUrl(() => '/geonetwork/srv/api'),
     {

--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -3,7 +3,7 @@
 
 FROM nginx:1.24-alpine
 
-ARG APP_NAME="plateforme"
+ARG APP_NAME="catalogue"
 
 COPY dist/apps/datahub/browser /usr/share/nginx/html/${APP_NAME}/
 COPY tools/docker/docker-entrypoint.sh /

--- a/tools/docker/nginx.conf
+++ b/tools/docker/nginx.conf
@@ -17,7 +17,7 @@ server {
         }
 
         location / {
-          try_files $uri $uri/ /plateforme/index.html;
+          try_files $uri $uri/ /catalogue/index.html;
 
           add_header Cache-Control 'max-age=86400'; # 24h
         }


### PR DESCRIPTION
This PR renames `plateforme` to `catalogue` to run under this path.