### PR TITLE
[Search page]: Remove html from cards

### DIFF
--- a/apps/datahub-e2e/src/e2e/search.cy.ts
+++ b/apps/datahub-e2e/src/e2e/search.cy.ts
@@ -29,6 +29,12 @@ describe('search', () => {
         .find('.mel-badge-button-primary')
         .should('not.contain', 'HAUTS-DE-FRANCE')
     })
+    it('should not dislay html in abstract', () => {
+      cy.get('mel-datahub-results-card-search')
+        .eq(5)
+        .find('[data-cy="abstract"]')
+        .should('not.contain', '<p>')
+    })
   })
 
   describe('search header carousel', () => {

--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -80,6 +80,7 @@ import { DatasetVisualisationComponent } from './dataset/dataset-visualisation/d
 import { MelMapViewComponent } from './dataset/dataset-visualisation/map-view/map-view.component'
 import { MelDataViewComponent } from './dataset/dataset-visualisation/data-view/data-view.component'
 import { environment } from '../environments/environnment'
+import { StripHtmlPipe } from './common/strip-html.pipe'
 
 @NgModule({
   declarations: [
@@ -121,6 +122,7 @@ import { environment } from '../environments/environnment'
     DatasetVisualisationComponent,
     MelMapViewComponent,
     MelDataViewComponent,
+    StripHtmlPipe,
   ],
   imports: [
     BrowserModule,

--- a/apps/datahub/src/app/common/results-list-item/results-card-search/results-card-search.component.html
+++ b/apps/datahub/src/app/common/results-list-item/results-card-search/results-card-search.component.html
@@ -27,8 +27,8 @@
     </div>
   </div>
   <div class="flex flex-col justify-between grow">
-    <div class="line-clamp-3 text-[15px] text-gray-2">
-      {{ record.abstract }}
+    <div data-cy="abstract" class="line-clamp-3 text-[15px] text-gray-2">
+      {{ record.abstract | stripHtml }}
     </div>
     <div class="flex justify-between gap-1 font-semibold">
       <div class="flex flex-col text-gray-1 gap-[3px] w-9/12">

--- a/apps/datahub/src/app/common/strip-html.pipe.ts
+++ b/apps/datahub/src/app/common/strip-html.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core'
+import { DomSanitizer } from '@angular/platform-browser'
+
+@Pipe({ name: 'stripHtml' })
+export class StripHtmlPipe implements PipeTransform {
+  constructor(private sanitizer: DomSanitizer) {}
+
+  transform(value: string): string {
+    const doc = new DOMParser().parseFromString(value, 'text/html')
+    return doc.body.textContent || ''
+  }
+}


### PR DESCRIPTION
PR adds a `StripHtmlPipe` to remove html tags and ignore its formatting in search cards.

Should resolve
![cards-html](https://github.com/camptocamp/mel-dataplatform/assets/6329425/09a02828-0990-44e5-852f-83396f19bce2)
to
![cards-nohtml](https://github.com/camptocamp/mel-dataplatform/assets/6329425/4f349137-0e14-461c-aa9a-f854b316b7d5)
