### PR TITLE
Dataset page: Change update date to use resourceUpdated

### DIFF
--- a/apps/datahub/src/app/dataset/dataset-information/dataset-information.component.ts
+++ b/apps/datahub/src/app/dataset/dataset-information/dataset-information.component.ts
@@ -15,7 +15,7 @@ export class DatasetInformationComponent {
   constructor(public translateService: TranslateService) {}
 
   get lastUpdate() {
-    return this.record?.recordUpdated?.toLocaleDateString(
+    return this.record?.resourceUpdated?.toLocaleDateString(
       this.translateService.currentLang
     )
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@ngx-translate/core": "^15.0.0",
         "@nx/angular": "17.2.8",
         "@vendure/ngx-translate-extract": "^9.0.3",
-        "geonetwork-ui": "^2.3.0-dev.179fba83",
+        "geonetwork-ui": "^2.3.0-dev.139106e0",
         "rxjs": "~7.8.0",
         "tippy.js": "^6.3.7",
         "tslib": "^2.3.0",
@@ -2467,9 +2467,9 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "1.1.0-RC.3",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.1.0-RC.3.tgz",
-      "integrity": "sha512-XZJwp0vxTQGtJD3t4GdTHJDLTidlPmv0sBvXskEt0A0cmrdaGUgBqr8KPeDfhjZfq99WFcXv/Gb3+hQXA0+LmQ==",
+      "version": "1.1.0-RC.4",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.1.0-RC.4.tgz",
+      "integrity": "sha512-7FLOJpzDXM/fSceUm97P8jzvPKZ2EUZmkP4CSFjC2AMOIjWyE70zMPIr76Z2ISF2Z4AavYwfaMnQI/Klb21yZw==",
       "dependencies": {
         "@rgrove/parse-xml": "^4.1.0"
       },
@@ -4681,9 +4681,9 @@
       }
     },
     "node_modules/@ngrx/component": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/@ngrx/component/-/component-17.1.1.tgz",
-      "integrity": "sha512-Zu9jEjvZ7H2YNCVLMvwXOlD0ecuyTXvWi6CBUz8vHz01G9AjxI0I6noo1y32nUv/2QFZgOmgpAcbqw5D8Zta4w==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/@ngrx/component/-/component-17.2.0.tgz",
+      "integrity": "sha512-Ahxa1tZ1vhsaZPOtN8cBFyenYZZQiHtpzCSCldSDk1fvTsLlUo0oEikUlxEOspkRSLDB+DutLFeZzJgXPCsMGQ==",
       "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
@@ -12597,9 +12597,9 @@
       "integrity": "sha512-osHqhtjojpCsACVnuD11xO5g9xaCyw7Qqn/C2KParkMv42i8jrJJgx3g7mkHfpxwhy9MnOJr8+pKOdZ7qzgizg=="
     },
     "node_modules/embla-carousel": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.0.1.tgz",
-      "integrity": "sha512-RsaMRyBCd144N95gb3XoI+H9zj3RI4y0qcfvKYEh2tIAIEenL9CW9vwzltCeoYkWYipGdkvup+HGT9ewG1YTEw=="
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.0.2.tgz",
+      "integrity": "sha512-bogsDO8xosuh/l3PxIvA5AMl3+BnRVAse9sDW/60amzj4MbGS5re4WH5eVEXiuH8G1/3G7QUAX2QNr3Yx8z5rA=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -14213,9 +14213,9 @@
       }
     },
     "node_modules/geonetwork-ui": {
-      "version": "2.3.0-dev.f736344f",
-      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.3.0-dev.f736344f.tgz",
-      "integrity": "sha512-SedVBPLPmxAuszT9zYck9G8Oaaknz6IMe/nwEuihnJdbXTnavtq1FSxYk00jKMSfuc0lytg6g6PWPYMe9is0oA==",
+      "version": "2.3.0-dev.139106e0",
+      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.3.0-dev.139106e0.tgz",
+      "integrity": "sha512-2Rzx7Yx5lQXAEr0bKQ04mzYg48S6gr6AuecN81ZmyBJIfWC4EsvGOO2mAsnsqTU/1ghBRRY87Vlvj/pwRbd0xg==",
       "dependencies": {
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
         "@camptocamp/ogc-client": "^1.1.0-RC.3",
@@ -14281,12 +14281,12 @@
       }
     },
     "node_modules/geonetwork-ui/node_modules/@angular-devkit/architect": {
-      "version": "0.1602.13",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.13.tgz",
-      "integrity": "sha512-ejrOYoXgbhDYjdaW4B2SyWeb6AqR8vqqzMyvCq2JX7fo08IhLnVu1fcl0fwr161l37TuzgPNWrHSciOzzmZDkw==",
+      "version": "0.1602.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.1602.14.tgz",
+      "integrity": "sha512-eSdONEV5dbtLNiOMBy9Ue9DdJ1ct6dH9RdZfYiedq6VZn0lejePAjY36MYVXgq2jTE+v/uIiaNy7caea5pt55A==",
       "peer": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.13",
+        "@angular-devkit/core": "16.2.14",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -14296,15 +14296,15 @@
       }
     },
     "node_modules/geonetwork-ui/node_modules/@angular-devkit/build-angular": {
-      "version": "16.2.13",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.13.tgz",
-      "integrity": "sha512-2G8gnBpBKcu+/jJH5DJZyMgn2RwDFPgiNSkcLKFg5DdqVFVT3CCoZAobfpAEMndrysfMmoUPGuAmsgCfdczQjg==",
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-16.2.14.tgz",
+      "integrity": "sha512-bXQ6i7QPhwmYHuh+DSNkBhjTIHQF0C6fqZEg2ApJA3NmnzE98oQnmJ9AnGnAkdf1Mjn3xi2gxoZWPDDxGEINMw==",
       "peer": true,
       "dependencies": {
         "@ampproject/remapping": "2.2.1",
-        "@angular-devkit/architect": "0.1602.13",
-        "@angular-devkit/build-webpack": "0.1602.13",
-        "@angular-devkit/core": "16.2.13",
+        "@angular-devkit/architect": "0.1602.14",
+        "@angular-devkit/build-webpack": "0.1602.14",
+        "@angular-devkit/core": "16.2.14",
         "@babel/core": "7.22.9",
         "@babel/generator": "7.22.9",
         "@babel/helper-annotate-as-pure": "7.22.5",
@@ -14316,7 +14316,7 @@
         "@babel/runtime": "7.22.6",
         "@babel/template": "7.22.5",
         "@discoveryjs/json-ext": "0.5.7",
-        "@ngtools/webpack": "16.2.13",
+        "@ngtools/webpack": "16.2.14",
         "@vitejs/plugin-basic-ssl": "1.0.1",
         "ansi-colors": "4.1.3",
         "autoprefixer": "10.4.14",
@@ -14359,7 +14359,7 @@
         "text-table": "0.2.0",
         "tree-kill": "1.2.2",
         "tslib": "2.6.1",
-        "vite": "4.5.2",
+        "vite": "4.5.3",
         "webpack": "5.88.2",
         "webpack-dev-middleware": "6.1.2",
         "webpack-dev-server": "4.15.1",
@@ -15031,12 +15031,12 @@
       }
     },
     "node_modules/geonetwork-ui/node_modules/@angular-devkit/build-webpack": {
-      "version": "0.1602.13",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.13.tgz",
-      "integrity": "sha512-H7CqnC0kvWR0Q45ZXsCO3M9lGd4dOajEmkCVmq7vVptU3nJRbCqJ0ZScj9bH5YSlcdO0jPbOdcTELWyEZ3BMFQ==",
+      "version": "0.1602.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/build-webpack/-/build-webpack-0.1602.14.tgz",
+      "integrity": "sha512-f+ZTCjOoA1SCQEaX3L/63ubqr/vlHkwDXAtKjBsQgyz6srnETcjy96Us5k/LoK7/hPc85zFneqLinfqOMVWHJQ==",
       "peer": true,
       "dependencies": {
-        "@angular-devkit/architect": "0.1602.13",
+        "@angular-devkit/architect": "0.1602.14",
         "rxjs": "7.8.1"
       },
       "engines": {
@@ -15050,9 +15050,9 @@
       }
     },
     "node_modules/geonetwork-ui/node_modules/@angular-devkit/core": {
-      "version": "16.2.13",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.13.tgz",
-      "integrity": "sha512-6jTlYOIeYsOF/Vw/hBNusjoCmKJBByoyGS1Fu2Yav8ltxYK04aDtI73l9JJB/5Cpzhc4YELrMqBMH7in5Vowaw==",
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-16.2.14.tgz",
+      "integrity": "sha512-Ui14/d2+p7lnmXlK/AX2ieQEGInBV75lonNtPQgwrYgskF8ufCuN0DyVZQUy9fJDkC+xQxbJyYrby/BS0R0e7w==",
       "peer": true,
       "dependencies": {
         "ajv": "8.12.0",
@@ -15077,12 +15077,12 @@
       }
     },
     "node_modules/geonetwork-ui/node_modules/@angular-devkit/schematics": {
-      "version": "16.2.13",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.2.13.tgz",
-      "integrity": "sha512-uhhJZpppaeuT/2V6RiCheJKzS4bAZADL+Gw59VJaojqS8ssdG1UzvqRJokIzFzP7+MhHWylZBWUvWLQxuUvtsA==",
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-16.2.14.tgz",
+      "integrity": "sha512-B6LQKInCT8w5zx5Pbroext5eFFRTCJdTwHN8GhcVS8IeKCnkeqVTQLjB4lBUg7LEm8Y7UHXwzrVxmk+f+MBXhw==",
       "peer": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.13",
+        "@angular-devkit/core": "16.2.14",
         "jsonc-parser": "3.2.0",
         "magic-string": "0.30.1",
         "ora": "5.4.1",
@@ -15545,9 +15545,9 @@
       }
     },
     "node_modules/geonetwork-ui/node_modules/@ngtools/webpack": {
-      "version": "16.2.13",
-      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.13.tgz",
-      "integrity": "sha512-P5OiVp9MeMwVxihtC9NB4mx1Zlbup2DLMAWYAl8/kcFdRrRW+1YDQn93tlFToQDHGpPxkqW7cnFUPnA+QwQMYA==",
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-16.2.14.tgz",
+      "integrity": "sha512-3+zPP3Wir46qrZ3FEiTz5/emSoVHYUCH+WgBmJ57mZCx1qBOYh2VgllnPr/Yusl1sc/jUZjdwq/es/9ZNw+zDQ==",
       "peer": true,
       "engines": {
         "node": "^16.14.0 || >=18.10.0",
@@ -16292,13 +16292,13 @@
       }
     },
     "node_modules/geonetwork-ui/node_modules/@schematics/angular": {
-      "version": "16.2.13",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.13.tgz",
-      "integrity": "sha512-SFE9e7X/CEtzwGEqHUqXriAm4J4uTjcfoRXslc7BuqOKABM8RXPphGQsVG4xOt3n25kXXGkFO2dvDRHuLTP1fQ==",
+      "version": "16.2.14",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-16.2.14.tgz",
+      "integrity": "sha512-YqIv727l9Qze8/OL6H9mBHc2jVXzAGRNBYnxYWqWhLbfvuVbbldo6NNIIjgv6lrl2LJSdPAAMNOD5m/f6210ug==",
       "peer": true,
       "dependencies": {
-        "@angular-devkit/core": "16.2.13",
-        "@angular-devkit/schematics": "16.2.13",
+        "@angular-devkit/core": "16.2.14",
+        "@angular-devkit/schematics": "16.2.14",
         "jsonc-parser": "3.2.0"
       },
       "engines": {
@@ -17141,9 +17141,9 @@
       }
     },
     "node_modules/geonetwork-ui/node_modules/vite": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
-      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.3.tgz",
+      "integrity": "sha512-kQL23kMeX92v3ph7IauVkXkikdDRsYMGTVl5KY2E9OY4ONLvkHf04MDTbnfo6NKxZiDLWzVpP5oTa8hQD8U3dg==",
       "peer": true,
       "dependencies": {
         "esbuild": "^0.18.10",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ngx-translate/core": "^15.0.0",
     "@nx/angular": "17.2.8",
     "@vendure/ngx-translate-extract": "^9.0.3",
-    "geonetwork-ui": "^2.3.0-dev.179fba83",
+    "geonetwork-ui": "^2.3.0-dev.139106e0",
     "rxjs": "~7.8.0",
     "tippy.js": "^6.3.7",
     "tslib": "^2.3.0",


### PR DESCRIPTION
This is a bugfix. Right now we are displaying the last update date of the metadata instead we should display the update date of the data. This PR fixes it.