### PR TITLE
Homepage: Fix french title on homepage

### DIFF
--- a/resources/translations/fr_MEL.json
+++ b/resources/translations/fr_MEL.json
@@ -7,7 +7,7 @@
   "mel.common.footer.newletter.signup": "S'inscrire à l'infolettre",
   "mel.common.footer.newsletter.inform": "Restez informés de l'actualité de la MEL en vous inscrivant à l'infolettre !",
   "mel.common.footer.social": "Réseaux sociaux",
-  "mel.datahub.home.title": "Métropole Européenne Lille",
+  "mel.datahub.home.title": "Métropole Européenne de Lille",
   "mel.datahub.multiselect.filter.placeholder": "Rechercher",
   "mel.datahub.search.clear": "Effacer",
   "mel.datahub.search.filters.license": "Licence",


### PR DESCRIPTION
This PR fixes the title on the homepage in the french translation.

![image](https://github.com/camptocamp/mel-dataplatform/assets/133115263/ec1a6c54-cba9-4ce2-96ed-e159b5d8fbb5)
