### PR TITLE
Remove google fonts from index.html, change text on dataset page

### DIFF
--- a/apps/datahub/src/index.html
+++ b/apps/datahub/src/index.html
@@ -5,8 +5,6 @@
     <title>dataMEL</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="stylesheet" href="assets/css/materials-symbols-outline.css" />
     <link rel="stylesheet" href="assets/css/default-fonts.css" />
   </head>

--- a/resources/translations/fr_MEL.json
+++ b/resources/translations/fr_MEL.json
@@ -64,7 +64,7 @@
   "mel.record.preview": "Visualisation",
   "mel.record.preview.load": "Chargement des données",
   "mel.record.preview.select": "Source des données",
-  "mel.record.preview.subtitle": "Vous pouvez choisir différentes visualisation afin d'apprécier le jeu données. “Cartographie” vous présente les données sous forme de Pin Map, “Tableau” vous permet de consulter les données sous forme brute et “Analyse” vous donne la possibilité de jongler entre différentes Dataviz.",
+  "mel.record.preview.subtitle": "Visualisez la donnée sous forme de carte, de tableau ou de graphique simple que vous pouvez configurer à partir du contenu du jeu de données.",
   "mel.record.tab.chart": "Analyse",
   "mel.record.tab.data": "Tableau",
   "mel.record.tab.map": "Cartographie",


### PR DESCRIPTION
This PR removes the google fonts from index.html and changes the text of the visualisation block on the dataset page.