### PR TITLE
[Footer]: Change mentions légales URL

### DIFF
--- a/libs/mel/src/lib/footer/mel-datahub-footer.component.html
+++ b/libs/mel/src/lib/footer/mel-datahub-footer.component.html
@@ -173,7 +173,7 @@
         <li class="mb-0 md:mb-3 lg:mb-5">
           <a
             class="text-xs leading-3 mx-5 hover:text-red-600 hover:underline"
-            href="https://data.lillemetropole.fr/public/mentions-legales"
+            href="/public/mentions-legales"
             translate=""
             >mel.common.footer.legal</a
           >


### PR DESCRIPTION
This PR changes the URL link of the "mentions légales" button to the static page creates. It only works on prod, as the link on dev is : https://mel.integration.apps.gs-fr-prod.camptocamp.com/public/mentions-legales/