### PR TITLE
chore: Update gn-ui dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@ngx-translate/core": "^15.0.0",
         "@nx/angular": "17.3.2",
         "@vendure/ngx-translate-extract": "^9.0.3",
-        "geonetwork-ui": "^2.3.0-dev.cc25794c",
+        "geonetwork-ui": "2.3.0-dev.cc25794c",
         "rxjs": "~7.8.0",
         "tippy.js": "^6.3.7",
         "tslib": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ngx-translate/core": "^15.0.0",
     "@nx/angular": "17.3.2",
     "@vendure/ngx-translate-extract": "^9.0.3",
-    "geonetwork-ui": "^2.3.0-dev.cc25794c",
+    "geonetwork-ui": "2.3.0-dev.cc25794c",
     "rxjs": "~7.8.0",
     "tippy.js": "^6.3.7",
     "tslib": "^2.3.0",


### PR DESCRIPTION
This PR updates the geonetwork-ui version to get the recent changes/ fixes.

Attribution is there now:
![image](https://github.com/camptocamp/mel-dataplatform/assets/133115263/e4d2b7a5-65cd-4d96-90ad-0ad44334f98e)
