### PR TITLE
Update gn-ui to version 2.3.0

### DIFF
--- a/apps/datahub/src/app/dataset/dataset-page/dataset-page.component.html
+++ b/apps/datahub/src/app/dataset/dataset-page/dataset-page.component.html
@@ -59,14 +59,14 @@
 } } @else {
 <div class="mt-12 p-4 max-w-[600px] m-auto text-[13px]">
   @if((facade.error$ | async).notFound) {
-  <gn-ui-search-results-error
+  <gn-ui-error
     [type]="errorTypes.RECORD_NOT_FOUND"
     [recordId]="(facade.metadata$ | async).uniqueIdentifier"
-  ></gn-ui-search-results-error>
+  ></gn-ui-error>
   } @else if((facade.error$ | async).otherError) {}
-  <gn-ui-search-results-error
+  <gn-ui-error
     [type]="errorTypes.RECEIVED_ERROR"
     [error]="(facade.error$ | async).otherError"
-  ></gn-ui-search-results-error>
+  ></gn-ui-error>
 </div>
 }

--- a/apps/datahub/src/app/dataset/dataset-page/dataset-page.component.ts
+++ b/apps/datahub/src/app/dataset/dataset-page/dataset-page.component.ts
@@ -4,7 +4,7 @@ import {
   CatalogRecord,
   Keyword,
 } from 'geonetwork-ui/libs/common/domain/src/lib/model/record'
-import { combineLatest, map } from 'rxjs'
+import { combineLatest, map, startWith } from 'rxjs'
 
 @Component({
   selector: 'mel-datahub-dataset-page',
@@ -15,12 +15,12 @@ import { combineLatest, map } from 'rxjs'
 export class DatasetPageComponent {
   displayMap$ = combineLatest([
     this.facade.mapApiLinks$,
-    this.facade.geoDataLinks$,
+    this.facade.geoDataLinksWithGeometry$,
   ]).pipe(
-    map(
-      ([mapLinks, geoDataLinks]) =>
-        mapLinks?.length > 0 || geoDataLinks?.length > 0
-    )
+    map(([mapApiLinks, geoDataLinksWithGeometry]) => {
+      return mapApiLinks?.length > 0 || geoDataLinksWithGeometry?.length > 0
+    }),
+    startWith(false)
   )
   displayData$ = combineLatest([
     this.facade.dataLinks$,

--- a/apps/datahub/src/environments/environnment.ts
+++ b/apps/datahub/src/environments/environnment.ts
@@ -6,7 +6,7 @@ import packageJson from 'geonetwork-ui/package.json'
 
 export const environment = {
   production: false,
-  version: packageJson.version.split('-')[1].includes('dev')
+  version: packageJson.version.split('-')[1]?.includes('dev')
     ? 'main'
     : `v${packageJson.version.split('-')[0]}`,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "@mel-dataplatform/source",
       "version": "0.0.0",
-      "license": "MIT",
+      "license": "GPL-3.0",
       "dependencies": {
         "@angular/animations": "~17.0.0",
         "@angular/cdk": "^17.3.1",
@@ -29,7 +29,7 @@
         "@ngx-translate/core": "^15.0.0",
         "@nx/angular": "17.3.2",
         "@vendure/ngx-translate-extract": "^9.0.3",
-        "geonetwork-ui": "2.3.0-dev.cc25794c",
+        "geonetwork-ui": "2.3.0",
         "rxjs": "~7.8.0",
         "tippy.js": "^6.3.7",
         "tslib": "^2.3.0",
@@ -16329,9 +16329,9 @@
       }
     },
     "node_modules/geonetwork-ui": {
-      "version": "2.3.0-dev.cc25794c",
-      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.3.0-dev.cc25794c.tgz",
-      "integrity": "sha512-BQjZ3KfwxKkvNd1I/i6uVOMGbcvM7OStFz3I8nJq69GdZOSzN9kvFT/dgsyh2v9XQOPy2t0JcwGcOXWno2/zBg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.3.0.tgz",
+      "integrity": "sha512-ys21ztjaLAXv64M5WKWLEAqXAOqR2TcGYmw8Nv1SpgzhHrapn8ZHY9eiAp0tcJORGB771NczOQLPW9KhdyJ5Qw==",
       "dependencies": {
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
         "@camptocamp/ogc-client": "1.1.1-dev.ad6d9ab",
@@ -18470,9 +18470,9 @@
       }
     },
     "node_modules/geonetwork-ui/node_modules/@types/node": {
-      "version": "16.18.97",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.97.tgz",
-      "integrity": "sha512-4muilE1Lbfn57unR+/nT9AFjWk0MtWi5muwCEJqnOvfRQDbSfLCUdN7vCIg8TYuaANfhLOV85ve+FNpiUsbSRg==",
+      "version": "16.18.98",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.98.tgz",
+      "integrity": "sha512-fpiC20NvLpTLAzo3oVBKIqBGR6Fx/8oAK/SSf7G+fydnXMY1x4x9RZ6sBXhqKlCU21g2QapUsbLlhv3+a7wS+Q==",
       "optional": true,
       "peer": true
     },
@@ -24856,9 +24856,9 @@
       "devOptional": true
     },
     "node_modules/pg": {
-      "version": "8.11.5",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.5.tgz",
-      "integrity": "sha512-jqgNHSKL5cbDjFlHyYsCXmQDrfIX/3RsNwYqpd4N0Kt8niLuNoRNH+aazv6cOd43gPh9Y4DjQCtb+X0MH0Hvnw==",
+      "version": "8.12.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.12.0.tgz",
+      "integrity": "sha512-A+LHUSnwnxrnL/tZ+OLfqR1SxLN3c/pgDztZ47Rpbsd4jUytsTtwQo/TLPRzPJMp/1pbhYVhH9cuSZLAajNfjQ==",
       "dependencies": {
         "pg-connection-string": "^2.6.4",
         "pg-pool": "^3.6.2",
@@ -28492,9 +28492,9 @@
       }
     },
     "node_modules/typeorm/node_modules/jackspeak": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.1.2.tgz",
-      "integrity": "sha512-kWmLKn2tRtfYMF/BakihVVRzBKOxz4gJMiL2Rj91WnAB5TPZumSH99R/Yf1qE1u4uRimvCSJfm6hnxohXeEXjQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.0.tgz",
+      "integrity": "sha512-JVYhQnN59LVPFCEcVa2C3CrEKYacvjRfqIQl+h8oi91aLYQVWRYbxjPcv1bUiUy/kLmQaANrYfNMCO3kuEDHfw==",
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
       },
@@ -29903,9 +29903,9 @@
       }
     },
     "node_modules/xml-utils": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.9.0.tgz",
-      "integrity": "sha512-bE++owdhr9WNSar5MAL04c727SjSHyEtu2+0hTVbHPeJgzauy5bnhfJV3gdKwm4m+ZNjKmjM97WphKwxWqW1IA=="
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.10.1.tgz",
+      "integrity": "sha512-Dn6vJ1Z9v1tepSjvnCpwk5QqwIPcEFKdgnjqfYOABv1ngSofuAhtlugcUC3ehS1OHdgDWSG6C5mvj+Qm15udTQ=="
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ngx-translate/core": "^15.0.0",
     "@nx/angular": "17.3.2",
     "@vendure/ngx-translate-extract": "^9.0.3",
-    "geonetwork-ui": "2.3.0-dev.cc25794c",
+    "geonetwork-ui": "2.3.0",
     "rxjs": "~7.8.0",
     "tippy.js": "^6.3.7",
     "tslib": "^2.3.0",


### PR DESCRIPTION
This PR updates gn-ui to release 2.3.0 and applies the necessary changes to not propose the map tab for non-geospatial datasets from the OGC API.

This should also make the share and embed widgets use the stable `2.3.0` release of the web components instead of the `main` branch distribution.