### PR TITLE
[Fix]: Map reset is not working

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset.cy.ts
@@ -86,7 +86,7 @@ describe('datasets', () => {
 
   describe('Vizualisation block', () => {
     beforeEach(() => {
-      cy.visit('/dataset/ee965118-2416-4d48-b07e-bbc696f002c2')
+      cy.visit('/dataset/04bcec79-5b25-4b16-b635-73115f7456e4')
     })
     it('should display the vizualisation block', () => {
       cy.get('mel-datahub-dataset-visualisation').should('be.visible')

--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -23,6 +23,7 @@ import {
   GN_UI_VERSION,
   WEB_COMPONENT_EMBEDDER_URL,
   FieldsService,
+  PopupAlertComponent,
 } from 'geonetwork-ui'
 import {
   TranslateLoader,
@@ -105,6 +106,7 @@ import { MelFieldsService } from './search/service/fields.service'
     OverlayModule,
     FormsModule,
     MatTooltipModule,
+    PopupAlertComponent,
     FeatureDatavizModule,
     TranslateModule.forRoot({
       ...TRANSLATE_DEFAULT_CONFIG,

--- a/libs/mel/src/lib/mel.module.ts
+++ b/libs/mel/src/lib/mel.module.ts
@@ -17,6 +17,7 @@ import { CustomCarouselComponent } from './custom-carousel/custom-carousel.compo
 import { MelFuzzySearchComponent } from './fuzzy-search/fuzzy-search.component'
 import { MelAutocompleteComponent } from './autocomplete/autocomplete.component'
 import {
+  PopupAlertComponent,
   UiElementsModule,
   UiLayoutModule,
   UiWidgetsModule,
@@ -37,6 +38,7 @@ import { StripHtmlPipe } from './strip-html.pipe'
     MatIconModule,
     TranslateModule,
     ReactiveFormsModule,
+    PopupAlertComponent,
   ],
   declarations: [
     ResultsListComponent,

--- a/package-lock.json
+++ b/package-lock.json
@@ -18470,9 +18470,9 @@
       }
     },
     "node_modules/geonetwork-ui/node_modules/@types/node": {
-      "version": "16.18.98",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.98.tgz",
-      "integrity": "sha512-fpiC20NvLpTLAzo3oVBKIqBGR6Fx/8oAK/SSf7G+fydnXMY1x4x9RZ6sBXhqKlCU21g2QapUsbLlhv3+a7wS+Q==",
+      "version": "16.18.99",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.99.tgz",
+      "integrity": "sha512-X2Yc+NQaPXDuaR32UmFrTr3OXWaht756A6sJw56o4dehkySBZ0NWH30CCRviuC0KFwTDW/NTjrtbFHhYcHkd6g==",
       "optional": true,
       "peer": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@ngx-translate/core": "^15.0.0",
         "@nx/angular": "17.3.2",
         "@vendure/ngx-translate-extract": "^9.0.3",
-        "geonetwork-ui": "2.3.0",
+        "geonetwork-ui": "^2.4.0-dev.e1bb65c4",
         "rxjs": "~7.8.0",
         "tippy.js": "^6.3.7",
         "tslib": "^2.3.0",
@@ -11486,9 +11486,9 @@
       }
     },
     "node_modules/@wessberg/ts-evaluator/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
       "peer": true,
       "engines": {
         "node": ">=8.3.0"
@@ -14812,9 +14812,9 @@
       "integrity": "sha512-gUI9nhI2iBGF0OaYYLKOaOtliFMl+Bt1rY7VmEjwxOxqoYLub/D9xmduPEhbw2imE6gYkJKhIE5it+KE2ulVxQ=="
     },
     "node_modules/embla-carousel": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.1.3.tgz",
-      "integrity": "sha512-GiRpKtzidV3v50oVMly8S+D7iE1r96ttt7fSlvtyKHoSkzrAnVcu8fX3c4j8Ol2hZSQlVfDqDIqdrFPs0u5TWQ=="
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.1.5.tgz",
+      "integrity": "sha512-R6xTf7cNdR2UTNM6/yUPZlJFRmZSogMiRjJ5vXHO65II5MoUlrVYUAP0fHQei/py82Vf15lj+WI+QdhnzBxA2g=="
     },
     "node_modules/emittery": {
       "version": "0.13.1",
@@ -16329,9 +16329,9 @@
       }
     },
     "node_modules/geonetwork-ui": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.3.0.tgz",
-      "integrity": "sha512-ys21ztjaLAXv64M5WKWLEAqXAOqR2TcGYmw8Nv1SpgzhHrapn8ZHY9eiAp0tcJORGB771NczOQLPW9KhdyJ5Qw==",
+      "version": "2.4.0-dev.e1bb65c4",
+      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.4.0-dev.e1bb65c4.tgz",
+      "integrity": "sha512-yEQsuvHZDGchebxCWIt5fezkklLebSm1ADa37NtgYnebWd3cYsSueo9J09J48/iZoY4VFCxXkC0utgyixBKC+w==",
       "dependencies": {
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
         "@camptocamp/ogc-client": "1.1.1-dev.ad6d9ab",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ngx-translate/core": "^15.0.0",
     "@nx/angular": "17.3.2",
     "@vendure/ngx-translate-extract": "^9.0.3",
-    "geonetwork-ui": "2.3.0",
+    "geonetwork-ui": "^2.4.0-dev.e1bb65c4",
     "rxjs": "~7.8.0",
     "tippy.js": "^6.3.7",
     "tslib": "^2.3.0",


### PR DESCRIPTION
This PR fixes the map reset that was not working when going from one record to another.
The sources dropdown is now reset everytime a new record is opened.

This was fixed on gn-ui and this is just an upgrade.