### PR TITLE
Update gn-ui to stable 2.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "@ngx-translate/core": "^15.0.0",
         "@nx/angular": "17.3.2",
         "@vendure/ngx-translate-extract": "^9.0.3",
-        "geonetwork-ui": "^2.4.0-dev.e1bb65c4",
+        "geonetwork-ui": "2.3.1",
         "rxjs": "~7.8.0",
         "tippy.js": "^6.3.7",
         "tslib": "^2.3.0",
@@ -16329,9 +16329,9 @@
       }
     },
     "node_modules/geonetwork-ui": {
-      "version": "2.4.0-dev.e1bb65c4",
-      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.4.0-dev.e1bb65c4.tgz",
-      "integrity": "sha512-yEQsuvHZDGchebxCWIt5fezkklLebSm1ADa37NtgYnebWd3cYsSueo9J09J48/iZoY4VFCxXkC0utgyixBKC+w==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.3.1.tgz",
+      "integrity": "sha512-fxbkvLxEGEf1jUMsR2cy6zUOCYQNfpaznFAWVwvgHMPCe9z6VNne1hbmJuzaNajk+9K/Pt8thvdfRGQIAEAleQ==",
       "dependencies": {
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
         "@camptocamp/ogc-client": "1.1.1-dev.ad6d9ab",
@@ -18470,9 +18470,9 @@
       }
     },
     "node_modules/geonetwork-ui/node_modules/@types/node": {
-      "version": "16.18.99",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.99.tgz",
-      "integrity": "sha512-X2Yc+NQaPXDuaR32UmFrTr3OXWaht756A6sJw56o4dehkySBZ0NWH30CCRviuC0KFwTDW/NTjrtbFHhYcHkd6g==",
+      "version": "16.18.101",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.101.tgz",
+      "integrity": "sha512-AAsx9Rgz2IzG8KJ6tXd6ndNkVcu+GYB6U/SnFAaokSPNx2N7dcIIfnighYUNumvj6YS2q39Dejz5tT0NCV7CWA==",
       "optional": true,
       "peer": true
     },
@@ -24622,6 +24622,11 @@
         "node": ">=6"
       }
     },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
+      "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw=="
+    },
     "node_modules/pacote": {
       "version": "17.0.4",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-17.0.4.tgz",
@@ -28463,14 +28468,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/typeorm/node_modules/glob": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.1.tgz",
-      "integrity": "sha512-2jelhlq3E4ho74ZyVLN03oKdAZVUa6UDZzFLVH1H7dnoax+y9qyaq8zBkfDIggjniU19z0wU18y16jMB2eyVIw==",
+      "version": "10.4.2",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.2.tgz",
+      "integrity": "sha512-GwMlUF6PkPo3Gk21UxkCohOv0PLcIXVtKyLlpEI28R/cO/4eNOdmLk3CMW1wROV/WR/EsZOWAfBbBOqYvs88/w==",
       "dependencies": {
         "foreground-child": "^3.1.0",
         "jackspeak": "^3.1.2",
         "minimatch": "^9.0.4",
         "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
         "path-scurry": "^1.11.1"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@ngx-translate/core": "^15.0.0",
     "@nx/angular": "17.3.2",
     "@vendure/ngx-translate-extract": "^9.0.3",
-    "geonetwork-ui": "^2.4.0-dev.e1bb65c4",
+    "geonetwork-ui": "2.3.1",
     "rxjs": "~7.8.0",
     "tippy.js": "^6.3.7",
     "tslib": "^2.3.0",


### PR DESCRIPTION
PR sets gn-ui to a stable release (`2.3.1`). This should fix the [map reset](https://github.com/geonetwork/geonetwork-ui/releases/tag/v2.3.1) and ensure to not introduce any potential regressions from gn-ui's `main` branch.