### PR TITLE
[Dataset page] : Fix WFS/OGC api access

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset.cy.ts
@@ -196,37 +196,45 @@ describe('datasets', () => {
   })
 
   describe('API block', () => {
-    beforeEach(() => cy.visit('/dataset/ee965118-2416-4d48-b07e-bbc696f002c2'))
+    describe('When the link is working', () => {
+      beforeEach(() =>
+        cy.visit('/dataset/04bcec79-5b25-4b16-b635-73115f7456e4')
+      )
 
-    it('should display the API block', () => {
-      cy.get('mel-datahub-dataset-apis').should('be.visible')
-    })
-    it('should have API cards', () => {
-      cy.get('mel-datahub-dataset-apis')
-        .find('mel-datahub-custom-carousel')
-        .find('mel-datahub-api-card')
-        .should('have.length.gt', 0)
-    })
-    it('should display the swagger link', () => {
-      cy.get('mel-datahub-dataset-apis')
-        .find('mel-datahub-custom-carousel')
-        .find('mel-datahub-api-card')
-        .last()
-        .click()
-      cy.window().then((win) => {
-        cy.get('mel-datahub-api-form')
-          .find('a')
-          .invoke('attr', 'href')
-          .should('eq', `${win.location.origin}/data/swagger-ui/index.html`)
+      it('should display the API block', () => {
+        cy.get('mel-datahub-dataset-apis').should('be.visible')
       })
-    })
-    it('should open the api form', () => {
-      cy.get('mel-datahub-dataset-apis')
-        .find('mel-datahub-custom-carousel')
-        .find('mel-datahub-api-card')
-        .last()
-        .click()
-      cy.get('mel-datahub-api-form').should('be.visible')
+      it('should have API cards', () => {
+        cy.get('mel-datahub-dataset-apis')
+          .find('mel-datahub-custom-carousel')
+          .find('mel-datahub-api-card')
+          .should('have.length.gt', 0)
+      })
+      it('should display the swagger link', () => {
+        cy.get('mel-datahub-dataset-apis')
+          .find('mel-datahub-custom-carousel')
+          .find('mel-datahub-api-card')
+          .last()
+          .find('button')
+          .eq(1)
+          .click()
+        cy.window().then((win) => {
+          cy.get('mel-datahub-api-form')
+            .find('a')
+            .invoke('attr', 'href')
+            .should('eq', `${win.location.origin}/data/swagger-ui/index.html`)
+        })
+      })
+      it('should open the api form', () => {
+        cy.get('mel-datahub-dataset-apis')
+          .find('mel-datahub-custom-carousel')
+          .find('mel-datahub-api-card')
+          .last()
+          .find('button')
+          .eq(1)
+          .click()
+        cy.get('mel-datahub-api-form').should('be.visible')
+      })
     })
   })
 

--- a/apps/datahub-e2e/src/e2e/search.cy.ts
+++ b/apps/datahub-e2e/src/e2e/search.cy.ts
@@ -224,7 +224,7 @@ describe('search', () => {
       )
     })
   })
-  describe.only('pagination', () => {
+  describe('pagination', () => {
     beforeEach(() => {
       cy.visit('/search')
     })

--- a/apps/datahub/src/app/dataset/dataset-apis/api-card/api-card.component.html
+++ b/apps/datahub/src/app/dataset/dataset-apis/api-card/api-card.component.html
@@ -1,11 +1,9 @@
 <div
   [title]="link.name"
   [ngClass]="{
-    'cursor-pointer': displayApiFormButton,
     'bg-gray-7': currentlyActive
   }"
-  (click)="openRecordApiFormPanel()"
-  class="mel-card w-[330px] group relative h-40 p-4 overflow-hidden"
+  class="mel-card w-[330px] group relative h-40 p-4 overflow-hidden cursor-default"
 >
   <h1 class="font-bold text-[17px] line-clamp-2">
     {{ link.name || link.description }}
@@ -20,33 +18,36 @@
     >
       {{ link.accessServiceProtocol }}
     </span>
-    <gn-ui-copy-text-button
-      *ngIf="!displayApiFormButton"
-      [text]="link.url.toString()"
-      [tooltipText]="'mel.tooltip.url.copy' | translate"
-      [displayText]="false"
-    ></gn-ui-copy-text-button>
-    <button
-      *ngIf="displayApiFormButton"
-      type="button"
-      [ngClass]="{
-        'h-6 focus:bg-text-primary-dark': displayApiFormButton
-      }"
-      mat-raised-button
-      [matTooltip]="
-        !currentlyActive
-          ? ('mel.record.metadata.api.form.openForm' | translate)
-          : ('mel.record.metadata.api.form.closeForm' | translate)
-      "
-      matTooltipPosition="above"
-    >
-      <mat-icon
-        class="material-symbols-outlined pointer-events-none align-top card-icon"
+    <div class="flex flex-row gap-2 items-center">
+      <gn-ui-copy-text-button
+        [text]="link.url.toString()"
+        [tooltipText]="'mel.tooltip.url.copy' | translate"
+        [displayText]="false"
+      ></gn-ui-copy-text-button>
+      @if(displayApiFormButton){
+      <button
+        type="button"
         [ngClass]="{
-          'text-primary-dark opacity-100': currentlyActive
+          'h-6 focus:bg-text-primary-dark': displayApiFormButton
         }"
-        >more_horiz</mat-icon
+        (click)="openRecordApiFormPanel()"
+        mat-raised-button
+        [matTooltip]="
+          !currentlyActive
+            ? ('mel.record.metadata.api.form.openForm' | translate)
+            : ('mel.record.metadata.api.form.closeForm' | translate)
+        "
+        matTooltipPosition="above"
       >
-    </button>
+        <mat-icon
+          class="material-symbols-outlined pointer-events-none align-middle card-icon"
+          [ngClass]="{
+            'text-primary-dark opacity-100': currentlyActive
+          }"
+          >more_horiz</mat-icon
+        >
+      </button>
+      }
+    </div>
   </div>
 </div>

--- a/resources/translations/fr_MEL.json
+++ b/resources/translations/fr_MEL.json
@@ -73,6 +73,6 @@
   "mel.search.field.any.placeholder": "Rechercher un jeu de données",
   "mel.search.filter.generatedByWfs": "généré par une API",
   "mel.searchpage.subtitle.favorites": "Jeux de données suivis",
-  "mel.tooltip.url.copy": "Copier l'URL",
+  "mel.tooltip.url.copy": "Copier l'URL racine",
   "search.filters.categoryKeyword": "Mot clé"
 }


### PR DESCRIPTION
### Description

This PR adds a copy button for the root URL to the API cards.
This will allow users to add the service to QGIS, which was an issue in the case of WFS/OGC API services because of the "Output Format" param added through the API form. These params are not taken into account by QGIS when creating the service's layer anyway, so the root URL should be used for such ends. 