### PR TITLE
Fix: Ensure config is copied correctly in docker container

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -4,6 +4,7 @@
 FROM nginx:1.24-alpine
 
 ARG APP_NAME="catalogue"
+ENV APP_NAME=${APP_NAME}
 
 COPY dist/apps/${APP_NAME}/browser /usr/share/nginx/html/${APP_NAME}
 COPY tools/docker/docker-entrypoint.sh /


### PR DESCRIPTION
PR sets `APP_NAME` as `ENV` (in `dockerfile`) to be used by `entrypoint` to ensure config is copied to correct location