### PR TITLE
[Search page]: "Less filters" button should be on one line

### DIFF
--- a/apps/datahub/src/app/search/search-filters/search-filters.component.html
+++ b/apps/datahub/src/app/search/search-filters/search-filters.component.html
@@ -21,7 +21,7 @@
     }
   </div>
   <div
-    class="flex flex-row items-start gap-4 -ml-[2px] mt-2 justify-betwwen w-56"
+    class="flex flex-row items-start gap-4 -ml-[2px] mt-2 justify-betwwen w-60"
   >
     @if(displayCount !== searchConfig.length) {
     <button


### PR DESCRIPTION
### Description

This PR changes the styling of the "less filters" button on the search page to keep its text on one line.

### Screenshot

![image](https://github.com/user-attachments/assets/891508f0-e7e0-4a36-be5e-3aef989b7abc)
