### PR TITLE
[Dataset page] Add filename/extension to download attribute

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset.cy.ts
@@ -263,10 +263,14 @@ describe('datasets', () => {
         .first()
         .should('have.attr', 'download', '')
     })
-    it('should contain download attribute with filename data.json for json files', () => {
+    it('should contain download attribute with filename for json files', () => {
       cy.get('[data-cy="download-button"]')
         .eq(2)
-        .should('have.attr', 'download', 'data.json')
+        .should(
+          'have.attr',
+          'download',
+          'insee:rectangles_200m_menage_erbm.json'
+        )
     })
     it('should open link in new tab as fallback (if download attribute is ignored, for not same-origin)', () => {
       cy.get('[data-cy="download-button"]')

--- a/apps/datahub-e2e/src/e2e/dataset.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset.cy.ts
@@ -245,7 +245,7 @@ describe('datasets', () => {
     beforeEach(() => {
       cy.visit('/dataset/04bcec79-5b25-4b16-b635-73115f7456e4')
     })
-    it('should download button should contain the correct link and open in new tab', () => {
+    it('should contain the correct link in download button', () => {
       cy.get('[data-cy="download-button"]')
         .first()
         .invoke('attr', 'href')
@@ -254,6 +254,21 @@ describe('datasets', () => {
         'contain',
         '/geoserver/insee/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=insee%3Arectangles_200m_menage_erbm&OUTPUTFORMAT=csv'
       )
+      cy.get('[data-cy="download-button"]')
+        .first()
+        .should('have.attr', 'target', '_blank')
+    })
+    it('should contain empty download attribute for other files than json and geojson', () => {
+      cy.get('[data-cy="download-button"]')
+        .first()
+        .should('have.attr', 'download', '')
+    })
+    it('should contain download attribute with filename data.json for json files', () => {
+      cy.get('[data-cy="download-button"]')
+        .eq(2)
+        .should('have.attr', 'download', 'data.json')
+    })
+    it('should open link in new tab as fallback (if download attribute is ignored, for not same-origin)', () => {
       cy.get('[data-cy="download-button"]')
         .first()
         .should('have.attr', 'target', '_blank')

--- a/apps/datahub/src/app/dataset/dataset-downloads/download-item/download-item.component.html
+++ b/apps/datahub/src/app/dataset/dataset-downloads/download-item/download-item.component.html
@@ -28,7 +28,7 @@
       rel="noopener"
       [class]="'mel-primary-button font-medium text-nowrap'"
       data-cy="download-button"
-      download
+      [download]="downloadFileName"
       ><span translate>mel.dataset.download</span>
       <img src="assets/icons/download.svg" alt="download" />
     </a>

--- a/apps/datahub/src/app/dataset/dataset-downloads/download-item/download-item.component.ts
+++ b/apps/datahub/src/app/dataset/dataset-downloads/download-item/download-item.component.ts
@@ -15,12 +15,13 @@ export class MelDownloadItemComponent extends DownloadItemComponent {
 
   // note that the download attribute calling this getter only takes effect on same-origin resources
   get downloadFileName() {
-    let fileName = ''
+    let completeFileName = ''
+    const fileName = this.link.name ?? 'data'
     if (this.format === 'geojson') {
-      fileName = 'data.geojson'
+      completeFileName = `${fileName}.geojson`
     } else if (this.format === 'json') {
-      fileName = 'data.json'
+      completeFileName = `${fileName}.json`
     }
-    return fileName
+    return completeFileName
   }
 }

--- a/apps/datahub/src/app/dataset/dataset-downloads/download-item/download-item.component.ts
+++ b/apps/datahub/src/app/dataset/dataset-downloads/download-item/download-item.component.ts
@@ -12,4 +12,15 @@ export class MelDownloadItemComponent extends DownloadItemComponent {
     navigator.clipboard.writeText(this.link.url.href)
     ;(event.target as HTMLElement).blur()
   }
+
+  // note that the download attribute calling this getter only takes effect on same-origin resources
+  get downloadFileName() {
+    let fileName = ''
+    if (this.format === 'geojson') {
+      fileName = 'data.geojson'
+    } else if (this.format === 'json') {
+      fileName = 'data.json'
+    }
+    return fileName
+  }
 }


### PR DESCRIPTION
PR adds filename/extension to download attribute for json and geojson files. Other file formats should have a name and don't need download attribute. Note that download attribute only takes effect on same-origin.