### PR TITLE
Exclude Unknown Format Links and Update geonetwork-ui Package Version

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset.cy.ts
@@ -287,55 +287,74 @@ describe('datasets', () => {
   })
 
   describe('Downloads section', () => {
-    beforeEach(() => {
-      cy.visit('/dataset/04bcec79-5b25-4b16-b635-73115f7456e4')
-    })
-    it('should contain the correct link in download button', () => {
-      cy.get('[data-cy="download-button"]')
-        .first()
-        .invoke('attr', 'href')
-        .as('downloadLink')
-      cy.get('@downloadLink').should(
-        'contain',
-        '/geoserver/insee/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=insee%3Arectangles_200m_menage_erbm&OUTPUTFORMAT=csv'
-      )
-      cy.get('[data-cy="download-button"]')
-        .first()
-        .should('have.attr', 'target', '_blank')
-    })
-    it('should contain empty download attribute for other files than json and geojson', () => {
-      cy.get('[data-cy="download-button"]')
-        .first()
-        .should('have.attr', 'download', '')
-    })
-    it('should contain download attribute with filename for json files', () => {
-      cy.get('[data-cy="download-button"]')
-        .eq(2)
-        .should(
-          'have.attr',
-          'download',
-          'insee:rectangles_200m_menage_erbm.json'
+    describe('Dataset with ID 04bcec79-5b25-4b16-b635-73115f7456e4', () => {
+      beforeEach(() => {
+        cy.visit('/dataset/04bcec79-5b25-4b16-b635-73115f7456e4')
+      })
+      it('should contain the correct link in download button', () => {
+        cy.get('[data-cy="download-button"]')
+          .first()
+          .invoke('attr', 'href')
+          .as('downloadLink')
+        cy.get('@downloadLink').should(
+          'contain',
+          '/geoserver/insee/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=insee%3Arectangles_200m_menage_erbm&OUTPUTFORMAT=csv'
         )
-    })
-    it('should open link in new tab as fallback (if download attribute is ignored, for not same-origin)', () => {
-      cy.get('[data-cy="download-button"]')
-        .first()
-        .should('have.attr', 'target', '_blank')
-    })
-    it('should copy the link resource to clipboard when clicking on copy button', () => {
-      cy.get('body').focus()
-      cy.get('[data-cy="copy-button"]').first().click()
-      // attempt to make the whole page focused
-      cy.get('body').focus()
-
-      cy.window().then((win) => {
-        win.navigator.clipboard.readText().then((text) => {
-          expect(text).to.eq(
-            'https://www.geo2france.fr/geoserver/insee/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=insee%3Arectangles_200m_menage_erbm&OUTPUTFORMAT=csv'
+        cy.get('[data-cy="download-button"]')
+          .first()
+          .should('have.attr', 'target', '_blank')
+      })
+      it('should contain empty download attribute for other files than json and geojson', () => {
+        cy.get('[data-cy="download-button"]')
+          .first()
+          .should('have.attr', 'download', '')
+      })
+      it('should contain download attribute with filename for json files', () => {
+        cy.get('[data-cy="download-button"]')
+          .eq(2)
+          .should(
+            'have.attr',
+            'download',
+            'insee:rectangles_200m_menage_erbm.json'
           )
+      })
+      it('should open link in new tab as fallback (if download attribute is ignored, for not same-origin)', () => {
+        cy.get('[data-cy="download-button"]')
+          .first()
+          .should('have.attr', 'target', '_blank')
+      })
+      it('should copy the link resource to clipboard when clicking on copy button', () => {
+        cy.get('body').focus()
+        cy.get('[data-cy="copy-button"]').first().click()
+        // attempt to make the whole page focused
+        cy.get('body').focus()
+
+        cy.window().then((win) => {
+          win.navigator.clipboard.readText().then((text) => {
+            expect(text).to.eq(
+              'https://www.geo2france.fr/geoserver/insee/ows?SERVICE=WFS&REQUEST=GetFeature&VERSION=2.0.0&TYPENAMES=insee%3Arectangles_200m_menage_erbm&OUTPUTFORMAT=csv'
+            )
+          })
         })
       })
+
+
+
     })
+    describe('Dataset with ID ed34db28-5dd4-480f-bf29-dc08f0086131', () => {
+      beforeEach(() => {
+        cy.visit('/dataset/ed34db28-5dd4-480f-bf29-dc08f0086131')
+      })
+      it('should display the download section', () => {
+        cy.get('mel-datahub-dataset-downloads').should('be.visible')
+      })
+      it('should dispaly the correct number of available downloads', () => {
+        cy.get('mel-datahub-dataset-downloads')
+          .find('mel-datahub-download-item')
+          .should('have.length', 10)
+      })
+    })
+
   })
 
   describe('Related datasets section', () => {

--- a/apps/datahub-e2e/src/e2e/dataset.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset.cy.ts
@@ -337,9 +337,6 @@ describe('datasets', () => {
           })
         })
       })
-
-
-
     })
     describe('Dataset with ID ed34db28-5dd4-480f-bf29-dc08f0086131', () => {
       beforeEach(() => {
@@ -354,7 +351,6 @@ describe('datasets', () => {
           .should('have.length', 10)
       })
     })
-
   })
 
   describe('Related datasets section', () => {

--- a/apps/datahub/src/app/dataset/dataset-downloads/dataset-downloads.component.ts
+++ b/apps/datahub/src/app/dataset/dataset-downloads/dataset-downloads.component.ts
@@ -80,11 +80,11 @@ export class DatasetDownloadsComponent {
           : [of([] as DatasetDownloadDistribution[])]),
       ]).pipe(
         map(flattenArray),
-        map(removeLinksWithUnknownFormat),
         map(removeDuplicateLinks),
         map((downloadLinks) => {
           return [...otherLinks, ...downloadLinks, ...esriRestLinks]
         }),
+        map(removeLinksWithUnknownFormat),
         catchError((e) => {
           this.error = e.message
           return of([...otherLinks, ...esriRestLinks])
@@ -98,8 +98,8 @@ export class DatasetDownloadsComponent {
 const flattenArray = (arrayOfArrays) =>
   arrayOfArrays.reduce((prev, curr) => [...prev, ...curr], [])
 
-const removeLinksWithUnknownFormat = (wfsDownloadLinks) =>
-  wfsDownloadLinks.filter((link) => !!getFileFormat(link))
+const removeLinksWithUnknownFormat = (downloadLinks) =>
+  downloadLinks.filter((link) => !!getFileFormat(link))
 
 const removeDuplicateLinks = (wfsDownloadLinks) =>
   wfsDownloadLinks.filter(

--- a/apps/datahub/src/app/dataset/dataset-downloads/download-item/download-item.component.html
+++ b/apps/datahub/src/app/dataset/dataset-downloads/download-item/download-item.component.html
@@ -14,7 +14,7 @@
         data-cy="download-format"
         >{{ format || ('mel.downloads.format.unknown' | translate) }}</span
       >
-      @if(isFromWfs){<span
+      @if(isFromApi){<span
         class="pl-2 inline-flex items-center text-gray-800 text-sm"
         translate=""
         >mel.search.filter.generatedByWfs</span

--- a/apps/datahub/src/app/dataset/dataset-downloads/downloads-list/downloads-list.component.html
+++ b/apps/datahub/src/app/dataset/dataset-downloads/downloads-list/downloads-list.component.html
@@ -28,7 +28,7 @@
     [link]="link"
     [color]="getLinkColor(link)"
     [format]="getLinkFormat(link)"
-    [isFromWfs]="isFromWfs(link)"
+    [isFromApi]="isFromApi(link)"
   ></mel-datahub-download-item>
 </div>
 } }

--- a/apps/home-e2e/src/e2e/home.cy.ts
+++ b/apps/home-e2e/src/e2e/home.cy.ts
@@ -36,10 +36,13 @@ describe('home', () => {
       cy.get('mel-datahub-carousel')
         .find('[title="carousel-arrow-right"]')
         .click()
+      cy.get('mel-datahub-carousel')
+        .find('[title="carousel-arrow-right"]')
+        .click()
 
       cy.get('mel-datahub-carousel')
         .find('h1')
-        .eq(2)
+        .eq(3)
         .should('have.text', ' Leitungskataster Fernwärme AEW Energie AG ')
         .should('be.visible')
     })
@@ -53,12 +56,12 @@ describe('home', () => {
         cy.get('@firstResult').click()
         cy.url().should(
           'include',
-          'catalogue/dataset/a3774ef6-809d-4dd1-984f-9254f49cbd0a'
+          'catalogue/dataset/ed34db28-5dd4-480f-bf29-dc08f0086131'
         )
       })
       it('should create correct url to navigate to search on keyword click', () => {
         cy.get('mel-datahub-results-card-last-created')
-          .eq(1)
+          .eq(2)
           .find('.mel-badge-button-primary')
           .first()
           .click()

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@ngx-translate/core": "^15.0.0",
         "@nx/angular": "17.3.2",
         "@vendure/ngx-translate-extract": "^9.0.3",
-        "geonetwork-ui": "2.4.0-alpha.2.411f5f168",
+        "geonetwork-ui": "2.4.0-alpha.2.8ebef57d4",
         "rxjs": "~7.8.0",
         "tippy.js": "^6.3.7",
         "tslib": "^2.3.0",
@@ -17477,9 +17477,9 @@
       }
     },
     "node_modules/geonetwork-ui": {
-      "version": "2.4.0-alpha.2.411f5f168",
-      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.4.0-alpha.2.411f5f168.tgz",
-      "integrity": "sha512-LxtrU9GPXf0Ol0lgB3K5MXaaWsQd9E9NbkNM9ZLSSFYXzo5S/tYknZBaBiaX5E4l72yOQtzn4dwVo6J0u+lK7g==",
+      "version": "2.4.0-alpha.2.8ebef57d4",
+      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.4.0-alpha.2.8ebef57d4.tgz",
+      "integrity": "sha512-I4I7U3jzjttlaRHYqjwmryc355TBNTU97Ou4OHQYfT6Rv9pUcs5NHtHJNYAkVharobTPz8ppXrPOZDyNd0My1A==",
       "dependencies": {
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
         "@camptocamp/ogc-client": "1.1.1-dev.c75dcba",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@ngx-translate/core": "^15.0.0",
     "@nx/angular": "17.3.2",
     "@vendure/ngx-translate-extract": "^9.0.3",
-    "geonetwork-ui": "2.4.0-alpha.2.411f5f168",
+    "geonetwork-ui": "2.4.0-alpha.2.8ebef57d4",
     "rxjs": "~7.8.0",
     "tippy.js": "^6.3.7",
     "tslib": "^2.3.0",


### PR DESCRIPTION
### Description

- Updated the filtering logic in `DatasetDownloadsComponent` to exclude links with unknown formats after combining all link types (`otherLinks`, `esriRestLinks`, and `downloadLinks`). This ensures that only valid links with recognized formats are displayed in the UI.

- Upgraded `geonetwork-ui` package to `2.4.0-alpha.2.8ebef57d4`.  
  - This update declutters the download section by prioritizing OGC API Features.  
  - Redundant download links for the same format across multiple protocols are avoided.  

### Screenshots

![BeforeAfter copy](https://github.com/user-attachments/assets/bab19476-3a7c-4b3f-99b3-445978b08daa)











