### PR TITLE
Remove generated from API tag from Downloads

### DIFF
--- a/apps/datahub/src/app/dataset/dataset-downloads/download-item/download-item.component.html
+++ b/apps/datahub/src/app/dataset/dataset-downloads/download-item/download-item.component.html
@@ -14,11 +14,6 @@
         data-cy="download-format"
         >{{ format || ('mel.downloads.format.unknown' | translate) }}</span
       >
-      @if(isFromApi){<span
-        class="pl-2 inline-flex items-center text-gray-800 text-sm"
-        translate=""
-        >mel.search.filter.generatedByWfs</span
-      >}
     </div>
   </div>
   <div class="flex grow-1 gap-4">


### PR DESCRIPTION
### Description

This PR removes the "Generated by API" tag from the download items in the `MelDownloadItemComponent`.

### Screenshot

![api](https://github.com/user-attachments/assets/0a75c1f0-f99c-4b4a-8d2e-c992b25d4541)


