### PR TITLE
[Dataset page]: Hide detailed file button

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset.cy.ts
@@ -201,14 +201,15 @@ describe('datasets', () => {
         .find('a')
         .should('have.length', 4)
     })
-    it('should display the detailed file link and lead to it', () => {
-      cy.get('@mainInfo')
-        .children('div')
-        .eq(5)
-        .find('a')
-        .invoke('attr', 'href')
-        .should('include', '/geonetwork/srv/fre/catalog.search#/metadata')
-    })
+    // This link is not used at the time
+    // it('should display the detailed file link and lead to it', () => {
+    //   cy.get('@mainInfo')
+    //     .children('div')
+    //     .eq(5)
+    //     .find('a')
+    //     .invoke('attr', 'href')
+    //     .should('include', '/geonetwork/srv/fre/catalog.search#/metadata')
+    // })
 
     describe('When clicking on a category tag', () => {
       it('should navigate to home page with and search query parameters should be assigned a value', () => {

--- a/apps/datahub/src/app/dataset/dataset-information/dataset-information.component.html
+++ b/apps/datahub/src/app/dataset/dataset-information/dataset-information.component.html
@@ -7,7 +7,7 @@
       mel.dataset.informations
     </div>
   </div>
-  <div class="flex flex-col gap-8 border-b-[1px] border-gray-3 pb-2">
+  <div class="flex flex-col gap-8 border-b-[1px] border-gray-3 pb-7">
     @if (lastUpdate) {
       <div class="flex flex-row gap-2">
         <span class="font-semibold" translate="">mel.dataset.updatedOn</span>
@@ -58,7 +58,7 @@
         <span>{{ record.ownerOrganization?.name }}</span>
       </div>
     }
-    @if (record.landingPage) {
+    <!-- @if (record.landingPage) {
       <div class="flex flex-row gap-1">
         <a
           class="underline text-gray-2 text-sm"
@@ -71,7 +71,7 @@
           name="matOpenInNew"
         ></ng-icon>
       </div>
-    }
+    } -->
   </div>
   <div class="flex flex-col gap-2 pt-4">
     <span class="font-semibold" translate="">mel.dataset.share</span>


### PR DESCRIPTION
This PR hides the detailed file button from the dataset page. It's only commented out as it's a temporary solution.

![image](https://github.com/user-attachments/assets/f71e2c70-57d2-4d46-8a82-2eb04247a891)

