### PR TITLE
[Dataset page] Data preview fixes

### DIFF
--- a/apps/datahub/src/app/dataset/dataset-visualisation/dataset-visualisation.component.html
+++ b/apps/datahub/src/app/dataset/dataset-visualisation/dataset-visualisation.component.html
@@ -63,7 +63,10 @@
         </ng-template>
         @if (displayData) {
           <div class="block">
-            <mel-datahub-data-view mode="chart"></mel-datahub-data-view>
+            <mel-datahub-data-view
+              mode="chart"
+              [displaySource]="displaySource"
+            ></mel-datahub-data-view>
           </div>
           <ng-container *ngTemplateOutlet="dataViewShare"></ng-container>
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@ngx-translate/core": "^15.0.0",
         "@nx/angular": "^20.4.2",
         "@vendure/ngx-translate-extract": "^9.0.3",
-        "geonetwork-ui": "2.4.2-dev.9237c52b5",
+        "geonetwork-ui": "2.4.2-dev.369bfa6fb",
         "rxjs": "7.8.1",
         "tippy.js": "^6.3.7",
         "tslib": "^2.3.0",
@@ -14735,9 +14735,9 @@
       }
     },
     "node_modules/geonetwork-ui": {
-      "version": "2.4.2-dev.9237c52b5",
-      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.4.2-dev.9237c52b5.tgz",
-      "integrity": "sha512-5wsUSwBnbIalOVhLgwiKz4Mb0L9nUTLXZWBk7QvF2yeVNpX/SiDnFha60KdBcQBcMKAbhAhwhVkrfPUMLvWrHw==",
+      "version": "2.4.2-dev.369bfa6fb",
+      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.4.2-dev.369bfa6fb.tgz",
+      "integrity": "sha512-j4Lv5yKGEkpbyVqL+7CtSHEqRfVnS0BQIfAKdnRmOQ1ild4IV7HNR+1HHqu4y/4W/nPcDHNI6YRytIk5IWN3KQ==",
       "dependencies": {
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
         "@camptocamp/ogc-client": "1.1.1-dev.3e2d3cc",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ngx-translate/core": "^15.0.0",
     "@nx/angular": "^20.4.2",
     "@vendure/ngx-translate-extract": "^9.0.3",
-    "geonetwork-ui": "2.4.2-dev.9237c52b5",
+    "geonetwork-ui": "2.4.2-dev.369bfa6fb",
     "rxjs": "7.8.1",
     "tippy.js": "^6.3.7",
     "tslib": "^2.3.0",


### PR DESCRIPTION
PR hides source drop down for chart and updates gn-ui, which hopefully fixes the width of the `data-view-share.component` once its deployed.