### PR TITLE
[Chore]: Upgrade gn-ui to latest

### DIFF
--- a/apps/datahub-e2e/src/e2e/dataset.cy.ts
+++ b/apps/datahub-e2e/src/e2e/dataset.cy.ts
@@ -356,7 +356,7 @@ describe('datasets', () => {
 
   describe('Related datasets section', () => {
     it('should display the related datasets section', () => {
-      cy.visit('/dataset/ee965118-2416-4d48-b07e-bbc696f002c2')
+      cy.visit('/dataset/9e1ea778-d0ce-4b49-90b7-37bc0e448300')
       cy.get('[data-cy="related-records-section"]').should('be.visible')
       cy.get('[data-cy="related-records-section"]')
         .find('mel-datahub-results-card-last-created')

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@ngx-translate/core": "^15.0.0",
         "@nx/angular": "^20.4.2",
         "@vendure/ngx-translate-extract": "^9.0.3",
-        "geonetwork-ui": "2.4.2-dev.369bfa6fb",
+        "geonetwork-ui": "2.5.0-dev.bd37f68b3",
         "rxjs": "7.8.1",
         "tippy.js": "^6.3.7",
         "tslib": "^2.3.0",
@@ -3623,9 +3623,9 @@
       }
     },
     "node_modules/@frogcat/ttl2jsonld": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@frogcat/ttl2jsonld/-/ttl2jsonld-0.0.9.tgz",
-      "integrity": "sha512-oT3Abc9sEnwcCx9cTgRCTbz+Y/9fvbqfW22A5V4ChoQ8/P++2eAvlWgUghFoNm2V9U3/CCDSP9HTGJ51D+n1Uw==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@frogcat/ttl2jsonld/-/ttl2jsonld-0.0.10.tgz",
+      "integrity": "sha512-0NLM96V3ziZkkOlhixSZiXe8CzewECVNtSj04s2hW2e65SgzQPzM12VWSovuRIy+2UJA2Bjkf9405yrty9tgcg==",
       "bin": {
         "ttl2jsonld": "bin/cli.js"
       }
@@ -14735,9 +14735,9 @@
       }
     },
     "node_modules/geonetwork-ui": {
-      "version": "2.4.2-dev.369bfa6fb",
-      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.4.2-dev.369bfa6fb.tgz",
-      "integrity": "sha512-j4Lv5yKGEkpbyVqL+7CtSHEqRfVnS0BQIfAKdnRmOQ1ild4IV7HNR+1HHqu4y/4W/nPcDHNI6YRytIk5IWN3KQ==",
+      "version": "2.5.0-dev.bd37f68b3",
+      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.5.0-dev.bd37f68b3.tgz",
+      "integrity": "sha512-juuaCj+C5W2PpZpzLiuOCKgvPik/zwpZHQYt3TgRw9AO+6nJlg5KZsKyIjzqu9oD4CH4o1uAtAGOzpzXu+IZzQ==",
       "dependencies": {
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
         "@camptocamp/ogc-client": "1.1.1-dev.3e2d3cc",
@@ -20128,9 +20128,9 @@
       }
     },
     "node_modules/ol-mapbox-style": {
-      "version": "12.4.1",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-12.4.1.tgz",
-      "integrity": "sha512-KNcu7FJD04LFd+9iuNwFiislQ8GfzNdiGaWKRWRh21rm8N4CKIR436VycWbx2AyqQXiLxQaTidYYgSMPPXnt2A==",
+      "version": "12.5.0",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-12.5.0.tgz",
+      "integrity": "sha512-Wr06OhV+tHlNZzol4C3bbKwcyHjNTb+ThMa3ALRRIMKosZ8z8m6A4KyX19zfNq9TI70LugEtMa5FVR7l7BlQVw==",
       "dependencies": {
         "@maplibre/maplibre-gl-style-spec": "^23.1.0",
         "mapbox-to-css-font": "^3.0.2"
@@ -21915,16 +21915,28 @@
       }
     },
     "node_modules/rdflib": {
-      "version": "2.2.36",
-      "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-2.2.36.tgz",
-      "integrity": "sha512-dZ4Xvjm2nqKq3tfiL65veKxLi6DqQTawQE3iz/aO7VqnmXzwQH4ugrsJZ3sn2kRLLax/TX3/TgYoAWocTYLwMg==",
+      "version": "2.2.37",
+      "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-2.2.37.tgz",
+      "integrity": "sha512-rRMJs7CGaS2vEdkplKfbc9TSoKIrSa3Ls3x7P6LSTcKyyX0hIe51kjPkRbuhh4uJk36ZJeXY5ww99PZa9KAVww==",
       "dependencies": {
-        "@frogcat/ttl2jsonld": "^0.0.9",
+        "@babel/runtime": "^7.26.9",
+        "@frogcat/ttl2jsonld": "^0.0.10",
         "@xmldom/xmldom": "^0.8.10",
-        "cross-fetch": "^3.1.8",
-        "jsonld": "^8.3.2",
-        "n3": "^1.17.3",
-        "solid-namespace": "^0.5.3"
+        "cross-fetch": "^3.2.0",
+        "jsonld": "^8.3.3",
+        "n3": "^1.23.1",
+        "solid-namespace": "^0.5.4"
+      }
+    },
+    "node_modules/rdflib/node_modules/@babel/runtime": {
+      "version": "7.26.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
+      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/rdflib/node_modules/cross-fetch": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ngx-translate/core": "^15.0.0",
     "@nx/angular": "^20.4.2",
     "@vendure/ngx-translate-extract": "^9.0.3",
-    "geonetwork-ui": "2.4.2-dev.369bfa6fb",
+    "geonetwork-ui": "2.5.0-dev.bd37f68b3",
     "rxjs": "7.8.1",
     "tippy.js": "^6.3.7",
     "tslib": "^2.3.0",


### PR DESCRIPTION
This PR upgrades gn-ui to its latest version to get all of the recent changes concerning the MEL project (mostly regarding OGC collections)