### PR TITLE
[Dependencies]: Upgrade gn-ui to allow WFS charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@ngx-translate/core": "^15.0.0",
         "@nx/angular": "^20.4.2",
         "@vendure/ngx-translate-extract": "^9.0.3",
-        "geonetwork-ui": "2.4.3",
+        "geonetwork-ui": "2.4.4",
         "rxjs": "7.8.1",
         "tippy.js": "^6.3.7",
         "tslib": "^2.3.0",
@@ -8317,9 +8317,9 @@
       ]
     },
     "node_modules/@petamoriken/float16": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.1.tgz",
-      "integrity": "sha512-j+ejhYwY6PeB+v1kn7lZFACUIG97u90WxMuGosILFsl9d4Ovi0sjk0GlPfoEcx+FzvXZDAfioD+NGnnPamXgMA=="
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.9.2.tgz",
+      "integrity": "sha512-VgffxawQde93xKxT3qap3OH+meZf7VaSB5Sqd4Rqc+FP5alWbpOyan/7tRbOAvynjpG3GpdtAuGU/NdhQpmrog=="
     },
     "node_modules/@phenomnomnominal/tsquery": {
       "version": "5.0.1",
@@ -14667,9 +14667,9 @@
       }
     },
     "node_modules/geonetwork-ui": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.4.3.tgz",
-      "integrity": "sha512-AJkfOEbziwcql/ohjB2SkL7F23cq63w7e0SmkLV/DLkyEC37lzGBxm/8Ph6WE3gXSnaj76pF23zYlplu+WT3nA==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.4.4.tgz",
+      "integrity": "sha512-inraJeOxHZx8iTAuJtIYRDpJyyJlmPy3ml9kBR7pp0cR4glMiUxps8FDqWsRVQnuvnPekk3Lub3QV7/PnDrXVA==",
       "dependencies": {
         "@biesbjerg/ngx-translate-extract-marker": "^1.0.0",
         "@camptocamp/ogc-client": "1.1.1-dev.3e2d3cc",
@@ -19291,9 +19291,9 @@
       }
     },
     "node_modules/n3": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.24.0.tgz",
-      "integrity": "sha512-iE4V0aSa3gCaqb3E2HoxQhlmoe7Kqy1Uy56mO0eDo9u3kJKzjjPIIO5mHi1bGi+YCP0cYZDt95k58tSSO0GlgQ==",
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.24.2.tgz",
+      "integrity": "sha512-j/3PKmK0MA3tAohDCl9y1JDaNxp8wCnhTtrOOgZ1O17JVtWLkzHsp2jZ8YhY2uS4FWQAm6mExcXvl7C8lwXyaw==",
       "dependencies": {
         "buffer": "^6.0.3",
         "queue-microtask": "^1.1.2",
@@ -20361,9 +20361,9 @@
       }
     },
     "node_modules/parse-headers": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -20538,13 +20538,13 @@
       "dev": true
     },
     "node_modules/pg": {
-      "version": "8.13.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.13.3.tgz",
-      "integrity": "sha512-P6tPt9jXbL9HVu/SSRERNYaYG++MjnscnegFh9pPHihfoBSujsrka0hyuymMzeJKFWrcG8wvCKy8rCe8e5nDUQ==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.14.1.tgz",
+      "integrity": "sha512-0TdbqfjwIun9Fm/r89oB7RFQ0bLgduAhiIqIXOsyKoiC/L54DbuAAzIEN/9Op0f1Po9X7iCPXGoa/Ah+2aI8Xw==",
       "dependencies": {
         "pg-connection-string": "^2.7.0",
-        "pg-pool": "^3.7.1",
-        "pg-protocol": "^1.7.1",
+        "pg-pool": "^3.8.0",
+        "pg-protocol": "^1.8.0",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
@@ -20583,17 +20583,17 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.7.1.tgz",
-      "integrity": "sha512-xIOsFoh7Vdhojas6q3596mXFsR8nwBQBXX5JiV7p9buEVAGqYL4yFzclON5P9vFrpu1u7Zwl2oriyDa89n0wbw==",
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.8.0.tgz",
+      "integrity": "sha512-VBw3jiVm6ZOdLBTIcXLNdSotb6Iy3uOCwDGFAksZCXmi10nyRvnP2v3jl4d+IsLYRyXf6o9hIm/ZtUzlByNUdw==",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.7.1.tgz",
-      "integrity": "sha512-gjTHWGYWsEgy9MsY0Gp6ZJxV24IjDqdpTW7Eh0x+WfJLFsm/TJx1MzL6T0D88mBvkpxotCQ6TwW6N+Kko7lhgQ=="
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.8.0.tgz",
+      "integrity": "sha512-jvuYlEkL03NRvOoyoRktBK7+qU5kOvlAwvmrH8sr3wbLrOdVWsRxQfz8mMy9sZFsqJ1hEWNfdWKI4SAmoL+j7g=="
     },
     "node_modules/pg-types": {
       "version": "2.2.0",
@@ -21840,9 +21840,9 @@
       }
     },
     "node_modules/rdflib/node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -24414,9 +24414,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.28.5",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
-      "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ngx-translate/core": "^15.0.0",
     "@nx/angular": "^20.4.2",
     "@vendure/ngx-translate-extract": "^9.0.3",
-    "geonetwork-ui": "2.4.3",
+    "geonetwork-ui": "2.4.4",
     "rxjs": "7.8.1",
     "tippy.js": "^6.3.7",
     "tslib": "^2.3.0",


### PR DESCRIPTION
### Description

This PR upgrades `geonetwork-ui` to [2.4.4](https://github.com/geonetwork/geonetwork-ui/releases/tag/v2.4.4) following its release, to allow WFS charts.

### Architectural changes

none

### Screenshots

![image](https://github.com/user-attachments/assets/912cf5d6-76c9-4d03-9442-01705288bca0)

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label

### How to test

Go to dataset `/dataset/40194765-d317-4d76-9d97-0e2c0c5e54c0`
