### PR TITLE
[FIX] Last line of data-table not visible

### DIFF
--- a/apps/datahub-e2e/src/e2e/search.cy.ts
+++ b/apps/datahub-e2e/src/e2e/search.cy.ts
@@ -8,14 +8,14 @@ describe('search', () => {
     it('should display the number of result hits', () => {
       cy.get('[data-cy="searchResults"]').should(
         'include.text',
-        'Ensemble des données: 17'
+        'Ensemble des données: 18'
       )
     })
     it('should display the footer', () => {
       cy.get('mel-datahub-footer').should('be.visible')
     })
     it('should display the result hits in search card', () => {
-      cy.get('mel-datahub-results-card-search').should('have.length', 17)
+      cy.get('mel-datahub-results-card-search').should('have.length', 18)
     })
   })
 
@@ -304,7 +304,7 @@ describe('search', () => {
         cy.get('@result-cards').should('have.length', 3)
         cy.get('body').click()
         cy.get('[data-cy=filterResetBtn]').click()
-        cy.get('@result-cards').should('have.length', 17)
+        cy.get('@result-cards').should('have.length', 18)
       })
       it('should show close button and show less filters on click', () => {
         cy.get('@expandBtn').click()

--- a/apps/datahub/src/app/dataset/dataset-visualisation/data-view/data-view.component.html
+++ b/apps/datahub/src/app/dataset/dataset-visualisation/data-view/data-view.component.html
@@ -11,7 +11,7 @@
       ></gn-ui-dropdown-selector>
     }
   </div>
-  <div class="relative h-[420px] m-4">
+  <div class="relative h-[460px] m-4">
     @if (mode === 'table') {
       <gn-ui-table-view [link]="selectedLink$ | async"></gn-ui-table-view>
     }


### PR DESCRIPTION
### Description

This PR fixes a small bug where the last line of the data-table in the preview was not visible, because of a defined height (420px) that was too small.
In generic DH, the problem didn't exist, because the height of the table was set to 460px. This PR sets it to 

### Architectural changes

The following library now depends on [...]

None

### Screenshots

<img width="1327" height="805" alt="image" src="https://github.com/user-attachments/assets/d1bc9766-aeb4-4d0e-80d9-2f0f48565cfa" />

### Quality Assurance Checklist

- [x] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label