### PR TITLE
Preserve unknown formats in associated resources

### DIFF
--- a/apps/datahub/src/app/dataset/dataset-links/dataset-links.component.ts
+++ b/apps/datahub/src/app/dataset/dataset-links/dataset-links.component.ts
@@ -99,7 +99,6 @@ export class DatasetLinksComponent {
   )
 
   associatedLinks$ = this.facade.otherLinks$.pipe(
-    map((links) => removeLinksWithUnknownFormat(links)),
     map((links) => sortLinks(links))
   )
 }


### PR DESCRIPTION
### Description

Associated resources were being filtered to remove links with unknown formats, which contradicts their intended purpose. Associated resources should display all resources not otherwise categorized, regardless of whether their format can be recognized by the system.

### Screenshots

<img width="4032" height="1799" alt="Adobe Express - file" src="https://github.com/user-attachments/assets/0e8b2334-5346-420f-b2fa-2803ce91339f" />

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

1. Check the dataset `Aires de covoiturage - MEL`
2. Before the update: Missing resources with unknown formats in Associated Resources section
3. After the update: All associated resources now visible, including unknown format links
4. Verify: Download section still only shows recognized formats

<!--
Describe here the steps to confirm that the changes work as they should.
-->
