### PR TITLE
GSMEL-1060: Deactivate ogc-client cache

### DIFF
--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { AppComponent } from './app.component'
 import { DatasetPageComponent } from './dataset/dataset-page/dataset-page.component'
 import { SearchPageComponent } from './search/search-page/search-page.component'
 import { MelFieldsService } from './search/service/fields.service'
+import { setCacheExpiryDuration } from '@camptocamp/ogc-client'
 
 @NgModule({
   declarations: [AppComponent],
@@ -129,5 +130,7 @@ export class AppModule {
       'white',
       'Lato'
     )
+
+    setCacheExpiryDuration(-1)
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "@ngx-translate/core": "~16.0.4",
         "@nx/angular": "22.0.4",
         "@vendure/ngx-translate-extract": "~10.1.1",
-        "geonetwork-ui": "2.9.0",
+        "geonetwork-ui": "2.10.0-dev.984a9212e",
         "rxjs": "7.8.1",
         "tippy.js": "^6.3.7",
         "tslib": "^2.3.0",
@@ -4242,9 +4242,9 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "1.3.1-dev.12086e8",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.3.1-dev.12086e8.tgz",
-      "integrity": "sha512-VBgxdMexS/8DH6CM3JcToCwRYEsbf6yIV/z/h9yuC7gfV8OGQjVeZSRJSDPRhUQJF7CZ4UM6pVGL8bDJpzoyoA==",
+      "version": "1.3.1-dev.afd9c26",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.3.1-dev.afd9c26.tgz",
+      "integrity": "sha512-G2YKPSIZIlO5tN+n5e/3h9OOUL3TgueTux9DlL6YFxR2FeA/qult7y7I+BS1ycUbO03HmYwf6ke7PWocy45ogQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@rgrove/parse-xml": "^4.1.0"
@@ -20658,12 +20658,12 @@
       }
     },
     "node_modules/geonetwork-ui": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.9.0.tgz",
-      "integrity": "sha512-/K7Asa9T/J4pR0sdkc8QmJhuh89D80nyzCA+3Sp9O5fObUyMKUKrBZrpEmwNETcrXQHS66OZEK4STWMcf6Vz7g==",
+      "version": "2.10.0-dev.984a9212e",
+      "resolved": "https://registry.npmjs.org/geonetwork-ui/-/geonetwork-ui-2.10.0-dev.984a9212e.tgz",
+      "integrity": "sha512-AW4cTmLLj/yYP8L3uEOBl5TKXPtEQJgqqG2/fEF3xfDTrsG3NXtWK3q5vurKznubLSmgHAL8pBaZyxKSJRqoZw==",
       "dependencies": {
         "@biesbjerg/ngx-translate-extract-marker": "~1.0.0",
-        "@camptocamp/ogc-client": "1.3.1-dev.12086e8",
+        "@camptocamp/ogc-client": "1.3.1-dev.afd9c26",
         "@geospatial-sdk/core": "0.0.5-dev.61",
         "@geospatial-sdk/geocoding": "0.0.5-dev.61",
         "@geospatial-sdk/legend": "0.0.5-dev.61",
@@ -31569,9 +31569,9 @@
       }
     },
     "node_modules/zarrita": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.2.tgz",
-      "integrity": "sha512-BHP+Z+yemkl9pOogkO1XMOrJ5qI4RNqrmheqJeYtIhpiaW4uvqplYx/jGkMD6edQjIZRQhniFigJZE2oTh7dwQ==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/zarrita/-/zarrita-0.7.3.tgz",
+      "integrity": "sha512-wChTQ1Ox75INoQCzKAfLWAfB70JJ4KjdW8Sz5x4ZWrFB4Dw+YZdnxHTL0xSdsrB9EmKSeK7fS1Y+I2ibhfGbkw==",
       "license": "MIT",
       "dependencies": {
         "@zarrita/storage": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@ngx-translate/core": "~16.0.4",
     "@nx/angular": "22.0.4",
     "@vendure/ngx-translate-extract": "~10.1.1",
-    "geonetwork-ui": "2.9.0",
+    "geonetwork-ui": "2.10.0-dev.984a9212e",
     "rxjs": "7.8.1",
     "tippy.js": "^6.3.7",
     "tslib": "^2.3.0",


### PR DESCRIPTION
### Description

This PR deactivates the ogc-client cache. This is a quick fix to display all download links (that may take some time to be propagated by geoserver).

Todo:

- [x] export `setCacheExpiryDuration` in ogc-client and bump ogc-client and gn-ui

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Ingest datasets with the datafeeder and check if all download links are properly displayed in the datahub.

<!--
Describe here the steps to confirm that the changes work as they should.
-->
