### PR TITLE
Make e2e tests more stable

### DIFF
--- a/apps/datahub-e2e/src/e2e/search.cy.ts
+++ b/apps/datahub-e2e/src/e2e/search.cy.ts
@@ -91,7 +91,9 @@ describe('search', () => {
         cy.get('[id^=dropdown-multiselect-] label').as('options')
       }
       beforeEach(() => {
-        cy.visit('/search?producerOrg=Métropole%20Européenne%20de%20Lille')
+        cy.visit(
+          '/search?producerOrg=M%C3%A9tropole%20Europ%C3%A9enne%20de%20Lille'
+        )
       })
       it('should display the last created cards filtered by producer', () => {
         cy.get('mel-datahub-carousel')
@@ -178,6 +180,7 @@ describe('search', () => {
         cy.get('[id^=dropdown-multiselect-] label').eq(1).click()
         cy.url().should('include', 'producerOrg=DREAL')
         cy.get('mel-datahub-results-card-favorite').should('have.length', 1)
+        cy.get('body').click('bottomLeft')
         cy.get('@favoriteCard')
           .find('mel-datahub-heart-toggle')
           .first()

--- a/apps/datahub-e2e/src/e2e/search.cy.ts
+++ b/apps/datahub-e2e/src/e2e/search.cy.ts
@@ -60,10 +60,7 @@ describe('search', () => {
         .find('mel-datahub-results-card-last-created')
         .first()
         .find('h1')
-        .should(
-          'include.text',
-          " Aléa de débordement de cours d'eau de la Lys "
-        )
+        .should('not.be.empty')
 
       cy.get('.mel-carousel-step-dot').should('exist')
 
@@ -141,6 +138,7 @@ describe('search', () => {
           .find('mel-datahub-button')
           .first()
           .click()
+        cy.wait('@addFavoriteRequest')
         cy.get('mel-datahub-results-card-favorite').as('favoriteCard')
       })
       it('should display the correct subtitle', () => {
@@ -178,7 +176,8 @@ describe('search', () => {
       it('should display the filtered cards by producer when the last favorite card is deleted', () => {
         cy.get('mel-datahub-filter-dropdown').first().click()
         cy.get('[id^=dropdown-multiselect-] label').eq(1).click()
-        cy.get('body').click()
+        cy.url().should('include', 'producerOrg=DREAL')
+        cy.get('mel-datahub-results-card-favorite').should('have.length', 1)
         cy.get('@favoriteCard')
           .find('mel-datahub-heart-toggle')
           .first()
@@ -299,7 +298,7 @@ describe('search', () => {
         getFilterOptions()
         cy.get('@options').eq(1).click()
         cy.get('@result-cards').should('have.length', 3)
-        cy.get('body').click()
+        cy.get('body').click('bottomLeft')
         cy.get('[data-cy=filterResetBtn]').click()
         cy.get('@result-cards').should('have.length', 18)
       })

--- a/apps/datahub-e2e/src/e2e/search.cy.ts
+++ b/apps/datahub-e2e/src/e2e/search.cy.ts
@@ -60,7 +60,10 @@ describe('search', () => {
         .find('mel-datahub-results-card-last-created')
         .first()
         .find('h1')
-        .should('not.be.empty')
+        .should(
+          'include.text',
+          " Aléa de débordement de cours d'eau de la Lys "
+        )
 
       cy.get('.mel-carousel-step-dot').should('exist')
 


### PR DESCRIPTION
### Description

This PR intents to make the e2e tests more stable:

- Wait for addFavoriteRequest before asserting on favorite card in beforeEach
- Sync on URL and card count before interacting with favorite card after filter
- Use body.click('bottomLeft') to close dropdown without collapsing expanded panel
- ~Remove hardcoded carousel title assertion that depends on API result ordering~
- Properly percent-encode accented characters in producerOrg URL param to avoid 400 errors from stricter local dev server configurations
- Close CDK overlay backdrop before clicking heart toggle by adding  body.click('bottomLeft') after filter assertions

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->