### PR TITLE
Display record landing page link only for SUPERUSER and MEL roles

### DIFF
--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -8,6 +8,7 @@ import {
 import { BrowserModule } from '@angular/platform-browser'
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations'
 import { RouterModule } from '@angular/router'
+import { setCacheExpiryDuration } from '@camptocamp/ogc-client'
 import {
   MelDatahubFooterComponent,
   MelEmbeddedTranslateLoader,
@@ -28,7 +29,6 @@ import {
   FeatureSearchModule,
   FieldsService,
   GEONETWORK_UI_VERSION,
-  Gn4PlatformService,
   LOGIN_URL,
   provideGn4,
   provideRepositoryUrl,
@@ -42,7 +42,6 @@ import { AppComponent } from './app.component'
 import { DatasetPageComponent } from './dataset/dataset-page/dataset-page.component'
 import { SearchPageComponent } from './search/search-page/search-page.component'
 import { MelFieldsService } from './search/service/fields.service'
-import { setCacheExpiryDuration } from '@camptocamp/ogc-client'
 
 @NgModule({
   declarations: [AppComponent],
@@ -114,7 +113,6 @@ import { setCacheExpiryDuration } from '@camptocamp/ogc-client'
       useFactory: () => true,
     },
     { provide: FieldsService, useClass: MelFieldsService },
-    Gn4PlatformService,
   ],
   bootstrap: [AppComponent],
 })

--- a/apps/datahub/src/app/app.module.ts
+++ b/apps/datahub/src/app/app.module.ts
@@ -40,6 +40,7 @@ import {
 import { environment } from '../environments/environment'
 import { AppComponent } from './app.component'
 import { DatasetPageComponent } from './dataset/dataset-page/dataset-page.component'
+import { GeorchestraPlatformService } from './platform/georchestra-platform.service'
 import { SearchPageComponent } from './search/search-page/search-page.component'
 import { MelFieldsService } from './search/service/fields.service'
 
@@ -113,6 +114,7 @@ import { MelFieldsService } from './search/service/fields.service'
       useFactory: () => true,
     },
     { provide: FieldsService, useClass: MelFieldsService },
+    GeorchestraPlatformService,
   ],
   bootstrap: [AppComponent],
 })

--- a/apps/datahub/src/app/dataset/dataset-information/dataset-information.component.html
+++ b/apps/datahub/src/app/dataset/dataset-information/dataset-information.component.html
@@ -58,7 +58,7 @@
         <span>{{ record.ownerOrganization?.name }}</span>
       </div>
     }
-    @if (isDevEnv) {
+    @if (displayLandingPage$ | async) {
       <div class="flex flex-row gap-1">
         <a
           class="underline text-gray-2 text-sm"

--- a/apps/datahub/src/app/dataset/dataset-information/dataset-information.component.ts
+++ b/apps/datahub/src/app/dataset/dataset-information/dataset-information.component.ts
@@ -1,3 +1,4 @@
+import { AsyncPipe } from '@angular/common'
 import {
   ChangeDetectionStrategy,
   Component,
@@ -12,13 +13,15 @@ import {
   TranslateService,
 } from '@ngx-translate/core'
 import { CatalogRecord, Keyword, RouterFacade } from 'geonetwork-ui'
+import { map } from 'rxjs'
+import { GeorchestraPlatformService } from '../../platform/georchestra-platform.service'
 
 @Component({
   selector: 'mel-datahub-dataset-information',
   templateUrl: './dataset-information.component.html',
   styles: ``,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgIconComponent, TranslateDirective, TranslatePipe],
+  imports: [AsyncPipe, NgIconComponent, TranslateDirective, TranslatePipe],
   providers: [
     provideIcons({
       matOpenInNew,
@@ -28,6 +31,7 @@ import { CatalogRecord, Keyword, RouterFacade } from 'geonetwork-ui'
 export class DatasetInformationComponent {
   public translateService = inject(TranslateService)
   protected routerFacade = inject(RouterFacade, { optional: true })
+  private georchestraPlatformService = inject(GeorchestraPlatformService)
 
   @Input() record: Partial<CatalogRecord>
   iconsUrl = 'assets/icons/'
@@ -50,11 +54,15 @@ export class DatasetInformationComponent {
     )
   }
 
-  get isDevEnv() {
-    return (
-      window.location.hostname ===
-      'mel.integration.apps.gs-fr-prod.camptocamp.com'
-    )
+  get displayLandingPage$() {
+    return this.georchestraPlatformService
+      .getMyRoles()
+      .pipe(
+        map(
+          (roles) =>
+            roles.includes('ROLE_SUPERUSER') || roles.includes('ROLE_MEL')
+        )
+      )
   }
 
   onKeywordClick(query: string, keyword: Keyword) {

--- a/apps/datahub/src/app/platform/georchestra-platform.service.ts
+++ b/apps/datahub/src/app/platform/georchestra-platform.service.ts
@@ -1,0 +1,27 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http'
+import { inject, Injectable } from '@angular/core'
+import { Observable } from 'rxjs'
+import { map, shareReplay, tap } from 'rxjs/operators'
+
+@Injectable()
+export class GeorchestraPlatformService {
+  private httpClient = inject(HttpClient)
+
+  private headers = new HttpHeaders().set('Accept', 'application/json')
+
+  private whoami$ = this.httpClient
+    .get(`/whoami`, {
+      responseType: 'json',
+      withCredentials: true,
+      headers: this.headers,
+      observe: 'body',
+      reportProgress: false,
+    })
+    .pipe(shareReplay({ bufferSize: 1, refCount: true }))
+
+  getMyRoles(): Observable<string[]> {
+    return this.whoami$.pipe(
+      map((response: any) => response.GeorchestraUser?.roles || [])
+    )
+  }
+}

--- a/apps/datahub/src/app/search/search-header/search-header.component.ts
+++ b/apps/datahub/src/app/search/search-header/search-header.component.ts
@@ -8,7 +8,7 @@ import { TranslateDirective, TranslatePipe } from '@ngx-translate/core'
 import {
   CatalogRecord,
   FavoritesService,
-  Gn4PlatformService,
+  PlatformServiceInterface,
   RouterFacade,
   SearchFacade,
   SearchService,
@@ -36,7 +36,7 @@ export class SearchHeaderComponent {
   private searchService = inject(SearchService)
   public favoritesService = inject(FavoritesService)
   protected searchFacade = inject(SearchFacade)
-  private platformService = inject(Gn4PlatformService)
+  private platformService = inject(PlatformServiceInterface)
 
   private previousFilters: any = {}
   bannerKey = 'application-banner'

--- a/apps/home/src/app/app.module.ts
+++ b/apps/home/src/app/app.module.ts
@@ -16,7 +16,6 @@ import {
 } from '@ngx-translate/core'
 import {
   FeatureSearchModule,
-  Gn4PlatformService,
   LOGIN_URL,
   provideGn4,
   provideRepositoryUrl,
@@ -67,7 +66,6 @@ import { HomePageComponent } from './home/home-page/home-page.component'
       provide: LOGIN_URL,
       useFactory: () => '${current_url}?login',
     },
-    Gn4PlatformService,
   ],
   bootstrap: [AppComponent],
 })

--- a/apps/home/src/app/home/home-header/home-header.component.ts
+++ b/apps/home/src/app/home/home-header/home-header.component.ts
@@ -13,7 +13,7 @@ import {
 import { TranslateDirective, TranslatePipe } from '@ngx-translate/core'
 import {
   CatalogRecord,
-  Gn4PlatformService,
+  PlatformServiceInterface,
   SearchService,
   SortByField,
 } from 'geonetwork-ui'
@@ -45,7 +45,7 @@ import {
 })
 export class HomeHeaderComponent {
   private searchService = inject(SearchService)
-  private platformService = inject(Gn4PlatformService)
+  private platformService = inject(PlatformServiceInterface)
 
   HREF_ROUTE_SEARCH = `${DATAHUB_ROOT}/${DATAHUB_ROUTE_SEARCH}`
   bannerKey = 'application-banner'


### PR DESCRIPTION
### Description

This PR introduces a service to get the roles of the currently authenticated user (none if not authenticated).
For the roles SUPERUSER and MEL, the link to the landing page of the record is displayed, allowing to view the same record in GeoNetwork.

### Architectural changes

Fixed a direct dependency to `Gn4PlatformService`, using `PlatformServiceInterface` now instead.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

The link should only be displayed when authenticated as a user with the role MEL or SUPERUSER.
The link should not be displayed when not authenticated.
The link should not be displayed when authenticated without those roles.
