### PR TITLE
Fix results-card component 

### DIFF
--- a/libs/mel/src/lib/results-list-item/results-card-search/results-card-search.component.html
+++ b/libs/mel/src/lib/results-list-item/results-card-search/results-card-search.component.html
@@ -38,9 +38,9 @@
     <div class="flex justify-between gap-1 font-semibold">
       <div class="flex flex-col text-gray-1 gap-[3px] w-9/12">
         <div class="text-[12px] font-semibold truncate">
-          <span [title]="shownOrganization.name"
+          <span [title]="shownOrganization?.name"
             >{{ 'mel.record.metadata.producteur' | translate }} :
-            {{ shownOrganization.name }}</span
+            {{ shownOrganization?.name }}</span
           >
         </div>
         <div class="flex gap-1 font-semibold">


### PR DESCRIPTION
### Description

PR prevents app from breaking if record has no ownerOrganization. This also stops the filter drop downs from working.

<!--
Describe here the changes brought by this PR. Do not forget to link any relevant issue or discussion to help people review your work!
-->

### Screenshots

Fixes:

<img width="1894" height="634" alt="image" src="https://github.com/user-attachments/assets/1cbc5b13-ce1e-4e3f-9a6c-5caa65137b7a" />

<!--
If the changes incur visual changes, please include screenshots or an animated screen capture.
-->

### Quality Assurance Checklist

- [ ] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label

<!--
Please only check items relevant to your contribution. Thank you very much for your time and efforts!
-->

### How to test

Import a record without a `contactForResource/Object` entry such as https://mel.integration.apps.gs-fr-prod.camptocamp.com/geonetwork/srv/fre/catalog.search#/metadata/e0804260-4c10-4a0d-92c1-03111210e780 and check if the result cards display correctly and the filter overlays work.

<!--
Describe here the steps to confirm that the changes work as they should.
-->
