### PR TITLE
Force version of ogc-client to limit collection discovery requests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4242,9 +4242,9 @@
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "1.3.1-dev.afd9c26",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.3.1-dev.afd9c26.tgz",
-      "integrity": "sha512-G2YKPSIZIlO5tN+n5e/3h9OOUL3TgueTux9DlL6YFxR2FeA/qult7y7I+BS1ycUbO03HmYwf6ke7PWocy45ogQ==",
+      "version": "1.3.1-dev.bb345f0",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.3.1-dev.bb345f0.tgz",
+      "integrity": "sha512-zeFzc4aFucoxC/SmBoSfyRaeCAQU6UOsnV5CkjEFNcHG+V75TA5oPRZTiFZxun4ekMc21EDUvH0bvXHVcUljZQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@rgrove/parse-xml": "^4.1.0"

--- a/package.json
+++ b/package.json
@@ -92,5 +92,10 @@
     "ts-jest": "29.4.9",
     "ts-node": "10.9.1",
     "typescript": "5.9.3"
+  },
+  "overrides": {
+    "geonetwork-ui": {
+      "@camptocamp/ogc-client": "1.3.1-dev.bb345f0"
+    }
   }
 }


### PR DESCRIPTION
### Description

This PR forces the use of version 1.3.1-dev.bb345f0 of ogc-client, without bumping the geonetwork-ui lib.

Note: this can be reversed as soon as DataMEL uses a newer version of geonetwork-ui.

### Quality Assurance Checklist

- [X] Commit history is devoid of any _merge commits_ and readable to facilitate reviews
- [ ] If **new user stories** 🤏 are introduced: E2E tests were added
- [ ] If **breaking changes** 🪚 are introduced: add the `breaking change` label
- [ ] If **bugs** 🐞 are fixed: add the `backport <release branch>` label

### How to test

Create a record with a link pointing to a heavy OGC API Features collection like
https://data.lillemetropole.fr/geoserver/ogc/features/v1/collections/dsp_ilevia:emprunt/items
Check, when loading the record page, that the download links are shown quick, and way before the data preview finishes loading (or crashing).